### PR TITLE
Memory leak on RecorderEndpoint release

### DIFF
--- a/src/server/implementation/objects/RecorderEndpointImpl.cpp
+++ b/src/server/implementation/objects/RecorderEndpointImpl.cpp
@@ -172,11 +172,10 @@ RecorderEndpointImpl::release ()
 
   g_object_get (getGstreamerElement(), "state", &state, NULL);
 
-  if (state == 0 /* stop */) {
-    return;
+  if (state != 0 /* recording */) {
+    stopAndWait();
   }
 
-  stopAndWait();
 
   UriEndpointImpl::release();
 }


### PR DESCRIPTION
Release was leaking resources if the recorder was previously stopped, I mean you could never reach  UriEndpointImpl::release() in that case