### PR TITLE
Use format macro to fix compiler errors on 32bit systems.

### DIFF
--- a/src/gst-plugins/kmscompositemixer.c
+++ b/src/gst-plugins/kmscompositemixer.c
@@ -298,8 +298,8 @@ cb_latency (GstPad * pad, GstPadProbeInfo * info, gpointer data)
     return GST_PAD_PROBE_OK;
   }
 
-  GST_LOG_OBJECT (pad, "Modifing latency query. New latency %ld",
-      LATENCY * GST_MSECOND);
+  GST_LOG_OBJECT (pad, "Modifing latency query. New latency %" G_GUINT64_FORMAT,
+      (guint64) (LATENCY * GST_MSECOND));
 
   gst_query_set_latency (GST_PAD_PROBE_INFO_QUERY (info),
       TRUE, 0, LATENCY * GST_MSECOND);


### PR DESCRIPTION
Fixes errors on `i386` and `armhf`.