### PR TITLE
Allow the AppSrc pipeline DOT diagram to be returned

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,3 +20,4 @@ override_dh_strip:
 
 override_dh_auto_test:
 	dh_auto_build -- -j2 check ARGS=-j10
+

--- a/debian/rules
+++ b/debian/rules
@@ -18,5 +18,5 @@ override_dh_auto_configure:
 override_dh_strip:
 	dh_strip --dbg-package=kms-elements-6.0-dbg
 
-override_dh_auto_test:
-	dh_auto_build -- -j2 check ARGS=-j10
+#override_dh_auto_test:
+#	dh_auto_build -- -j2 check ARGS=-j10

--- a/debian/rules
+++ b/debian/rules
@@ -18,5 +18,5 @@ override_dh_auto_configure:
 override_dh_strip:
 	dh_strip --dbg-package=kms-elements-6.0-dbg
 
-#override_dh_auto_test:
-#	dh_auto_build -- -j2 check ARGS=-j10
+override_dh_auto_test:
+	dh_auto_build -- -j2 check ARGS=-j10

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -35,7 +35,6 @@
 #define VIDEO_APPSRC "video_appsrc"
 #define URIDECODEBIN "uridecodebin"
 #define RTSPSRC "rtspsrc"
-#define SOUPHTTPSRC "souphttpsrc"
 
 #define APPSRC_KEY "appsrc-key"
 G_DEFINE_QUARK (APPSRC_KEY, appsrc);

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -100,6 +100,7 @@ enum
   PROP_VIDEO_DATA,
   PROP_POSITION,
   PROP_NETWORK_CACHE,
+  PROP_PIPELINE,
   N_PROPERTIES
 };
 
@@ -254,6 +255,9 @@ kms_player_endpoint_get_property (GObject * object, guint property_id,
       g_value_set_int64 (value, position);
       break;
     }
+    case PROP_PIPELINE:
+      g_value_set_object (value, playerendpoint->priv->pipeline);
+      break;
     case PROP_NETWORK_CACHE:
       g_value_set_int (value, playerendpoint->priv->network_cache);
       break;
@@ -1090,6 +1094,11 @@ kms_player_endpoint_class_init (KmsPlayerEndpointClass * klass)
           "When using rtsp sources, the amount of ms to buffer",
           0, G_MAXINT, NETWORK_CACHE_DEFAULT,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY));
+
+  g_object_class_install_property (gobject_class, PROP_PIPELINE,
+      g_param_spec_object ("pipeline", "pipeline",
+          "Players private pipeline",
+          GST_TYPE_ELEMENT, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
   kms_player_endpoint_signals[SIGNAL_EOS] =
       g_signal_new ("eos",

--- a/src/server/implementation/objects/PlayerEndpointImpl.cpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.cpp
@@ -19,6 +19,7 @@
 #include "VideoInfo.hpp"
 #include <PlayerEndpointImplFactory.hpp>
 #include "PlayerEndpointImpl.hpp"
+#include <DotGraph.hpp>
 #include <jsonrpc/JsonSerializer.hpp>
 #include <KurentoException.hpp>
 #include <gst/gst.h>
@@ -31,6 +32,7 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define FACTORY_NAME "playerendpoint"
 #define VIDEO_DATA "video-data"
 #define POSITION "position"
+#define PIPELINE "pipeline"
 #define SET_POSITION "set-position"
 #define NS_TO_MS 1000000
 
@@ -154,6 +156,15 @@ int64_t PlayerEndpointImpl::getPosition ()
   g_object_get (G_OBJECT (element), POSITION, &position, NULL);
 
   return position / NS_TO_MS;
+}
+
+std::string PlayerEndpointImpl::getElementGstreamerDot ()
+{
+  GValue *pipeline;
+  g_object_get (G_OBJECT (element), PIPELINE, &pipeline, NULL);
+  return generateDotGraph (GST_BIN (pipeline),
+                           std::shared_ptr <GstreamerDotDetails> (new GstreamerDotDetails (
+                                 GstreamerDotDetails::SHOW_VERBOSE) ) );
 }
 
 void PlayerEndpointImpl::setPosition (int64_t position)

--- a/src/server/implementation/objects/PlayerEndpointImpl.hpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.hpp
@@ -50,6 +50,8 @@ public:
   virtual int64_t getPosition() override;
   virtual void setPosition (int64_t position) override;
 
+  virtual std::string getElementGstreamerDot() override;
+
   /* Next methods are automatically implemented by code generator */
   using UriEndpointImpl::connect;
   virtual bool connect (const std::string &eventType,

--- a/src/server/interface/elements.PlayerEndpoint.kmd.json
+++ b/src/server/interface/elements.PlayerEndpoint.kmd.json
@@ -91,6 +91,12 @@
           "readOnly": true
         },
         {
+          "name": "elementGstreamerDot",
+          "doc": "Returns the Gstreamer DOT string for this element's private pipeline",
+          "type": "String",
+          "readOnly": true
+        },
+        {
           "name": "position",
           "doc": "Get or set the actual position of the video in ms. .. note:: Setting the position only works for seekable videos",
           "type": "int64"


### PR DESCRIPTION
I needed a way to see how the AppSrc was creating its internal pipeline for debugging a memory issue I was facing. This allows the user to call getElementGstreamerDot() on a PlayerEndpoit to see how the uridecodebin pipeline is setup. 