### PR TITLE
prevent buffer increase when CPU loaded

### DIFF
--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -1279,7 +1279,7 @@ element_added (GstBin * bin, GstElement * element, gpointer data)
   if (g_strcmp0 (gst_plugin_feature_get_name (GST_PLUGIN_FEATURE
               (gst_element_get_factory (element))), RTSPSRC) == 0) {
     g_object_set (G_OBJECT (element), "latency", self->priv->network_cache,
-        NULL);
+        "drop-on-latency", TRUE, NULL);
   }
 }
 


### PR DESCRIPTION
Prevent frames from building up in the buffer if the CPU falls behind.

Prior discussion: https://groups.google.com/g/kurento/c/_IsI7tcdLVw/m/N_GB6SKLBAAJ
Related: https://github.com/Kurento/kms-core/pull/7

For testing purposes, I have a VM configured with one CPU. When I attempt to run three high-definition videos through KMS, the CPU becomes over taxed and KMS begins to buffer the incoming video. This leads to huge delays in displaying the video. I've seen as much as 2 minutes of video being buffered inside KMS and the player running at almost half speed and 2 minutes behind the live video. This also causes huge memory accumulation within KMS, often in the tens of gigabytes range. There seem to be two issues leading to the buffering of video and the delayed delivery of video to the browser.

1) I've set a 500ms network buffer on the rtspsrc gstreamer filter. However, as latency grows, the delay increases and packets seem to accumulate in the rtpjitterbuffer. The first "fix" is to allow the rtspsrc to discard packets at the latency level and not to increase it beyond the set network buffer size. I made a change in the kmsplayerendpoint.c file:

```c
element_added (GstBin * bin, GstElement * element, gpointer data)
{
  KmsPlayerEndpoint *self = KMS_PLAYER_ENDPOINT (data);


  if (g_strcmp0 (gst_plugin_feature_get_name (GST_PLUGIN_FEATURE
              (gst_element_get_factory (element))), RTSPSRC) == 0) {
    g_object_set (G_OBJECT (element), "latency", self->priv->network_cache,
        "drop-on-latency", TRUE, NULL);
  }
}
```

The change was to add "drop-on-latency" to the g_object_set command.

2) There is a queue element just before the vp8 encoder which can buffer up to 1 second of video. Other places where the queue element is used, KMS restricts the amount of buffering either to a smaller number or smaller time frame. When the vp8 encoder falls behind, packets can stack up in the queue and new frames will block until space is available in the queue. I made a change to lower the amount of buffering the queue can hold and to allow it to discard old frames when the buffer fills up. The change is made in the kms_enc_tree_bin_configure function in the kmsenctreebin.c file:

```c
  queue = gst_element_factory_make ("queue", NULL);
  g_object_set (queue, "leaky", 2, "max-size-buffers", 1, NULL);
```

These two fixes allow KMS to better handle high CPU load when decoding, transcoding, and delivering video. It also keeps KMS from consuming an increasing amount of memory due to the indefinite buffering of video. 