### PR TITLE
Add API support for MKV profile for recordings

### DIFF
--- a/src/gst-plugins/recorderendpoint/kmsavmuxer.c
+++ b/src/gst-plugins/recorderendpoint/kmsavmuxer.c
@@ -153,6 +153,11 @@ kms_av_muxer_create_muxer (KmsAVMuxer * self)
     case KMS_RECORDING_PROFILE_WEBM_VIDEO_ONLY:
     case KMS_RECORDING_PROFILE_WEBM_AUDIO_ONLY:
       return gst_element_factory_make ("webmmux", NULL);
+    case KMS_RECORDING_PROFILE_MKV:
+    case KMS_RECORDING_PROFILE_MKV_VIDEO_ONLY:
+    case KMS_RECORDING_PROFILE_MKV_AUDIO_ONLY:{
+      return gst_element_factory_make ("matroskamux", NULL);
+    }
     case KMS_RECORDING_PROFILE_MP4:
     case KMS_RECORDING_PROFILE_MP4_VIDEO_ONLY:
     case KMS_RECORDING_PROFILE_MP4_AUDIO_ONLY:{

--- a/src/gst-plugins/recorderendpoint/kmsrecorderendpoint.c
+++ b/src/gst-plugins/recorderendpoint/kmsrecorderendpoint.c
@@ -18,7 +18,7 @@
 #include "config.h"
 #endif
 
-#define _GNU_SOURCE // Enable GNU Extensions: 'ALLPERMS' is not POSIX
+#define _GNU_SOURCE             // Enable GNU Extensions: 'ALLPERMS' is not POSIX
 #include <sys/stat.h>
 
 #include <string.h>
@@ -968,6 +968,8 @@ set_appsink_caps (GstElement * appsink, const GstCaps * caps,
   }
 
   switch (profile) {
+    case KMS_RECORDING_PROFILE_MKV:
+    case KMS_RECORDING_PROFILE_MKV_VIDEO_ONLY:
     case KMS_RECORDING_PROFILE_WEBM:
     case KMS_RECORDING_PROFILE_WEBM_VIDEO_ONLY:
       /* Allow renegotiation of width and height because webmmux supports it */
@@ -1977,8 +1979,8 @@ bus_sync_signal_handler (GstBus * bus, GstMessage * msg, gpointer data)
     gst_task_pool_push (self->priv->pool, kms_recorder_endpoint_on_eos_message,
         self, NULL);
   } else if ((GST_MESSAGE_TYPE (msg) == GST_MESSAGE_STATE_CHANGED)
-      && (GST_OBJECT_CAST (KMS_BASE_MEDIA_MUXER_GET_PIPELINE (self->
-                  priv->mux)) == GST_MESSAGE_SRC (msg))) {
+      && (GST_OBJECT_CAST (KMS_BASE_MEDIA_MUXER_GET_PIPELINE (self->priv->
+                  mux)) == GST_MESSAGE_SRC (msg))) {
     GstState new_state, pending;
 
     gst_message_parse_state_changed (msg, NULL, &new_state, &pending);

--- a/src/gst-plugins/recorderendpoint/kmsrecorderendpoint.c
+++ b/src/gst-plugins/recorderendpoint/kmsrecorderendpoint.c
@@ -18,7 +18,7 @@
 #include "config.h"
 #endif
 
-#define _GNU_SOURCE             // Enable GNU Extensions: 'ALLPERMS' is not POSIX
+#define _GNU_SOURCE // Enable GNU Extensions: 'ALLPERMS' is not POSIX
 #include <sys/stat.h>
 
 #include <string.h>
@@ -1979,8 +1979,8 @@ bus_sync_signal_handler (GstBus * bus, GstMessage * msg, gpointer data)
     gst_task_pool_push (self->priv->pool, kms_recorder_endpoint_on_eos_message,
         self, NULL);
   } else if ((GST_MESSAGE_TYPE (msg) == GST_MESSAGE_STATE_CHANGED)
-      && (GST_OBJECT_CAST (KMS_BASE_MEDIA_MUXER_GET_PIPELINE (self->priv->
-                  mux)) == GST_MESSAGE_SRC (msg))) {
+      && (GST_OBJECT_CAST (KMS_BASE_MEDIA_MUXER_GET_PIPELINE (self->
+                  priv->mux)) == GST_MESSAGE_SRC (msg))) {
     GstState new_state, pending;
 
     gst_message_parse_state_changed (msg, NULL, &new_state, &pending);

--- a/src/server/implementation/objects/RecorderEndpointImpl.cpp
+++ b/src/server/implementation/objects/RecorderEndpointImpl.cpp
@@ -88,6 +88,11 @@ RecorderEndpointImpl::RecorderEndpointImpl (const boost::property_tree::ptree
     GST_INFO ("Set MP4 profile");
     break;
 
+  case MediaProfileSpecType::MKV:
+    g_object_set ( G_OBJECT (element), "profile", KMS_RECORDING_PROFILE_MKV, NULL);
+    GST_INFO ("Set MKV profile");
+    break;
+
   case MediaProfileSpecType::WEBM_VIDEO_ONLY:
     g_object_set ( G_OBJECT (element), "profile",
                    KMS_RECORDING_PROFILE_WEBM_VIDEO_ONLY, NULL);
@@ -98,6 +103,18 @@ RecorderEndpointImpl::RecorderEndpointImpl (const boost::property_tree::ptree
     g_object_set ( G_OBJECT (element), "profile",
                    KMS_RECORDING_PROFILE_WEBM_AUDIO_ONLY, NULL);
     GST_INFO ("Set WEBM AUDIO ONLY profile");
+    break;
+
+  case MediaProfileSpecType::MKV_VIDEO_ONLY:
+    g_object_set ( G_OBJECT (element), "profile",
+                   KMS_RECORDING_PROFILE_MKV_VIDEO_ONLY, NULL);
+    GST_INFO ("Set MKV VIDEO ONLY profile");
+    break;
+
+  case MediaProfileSpecType::MKV_AUDIO_ONLY:
+    g_object_set ( G_OBJECT (element), "profile",
+                   KMS_RECORDING_PROFILE_MKV_AUDIO_ONLY, NULL);
+    GST_INFO ("Set MKV AUDIO ONLY profile");
     break;
 
   case MediaProfileSpecType::MP4_VIDEO_ONLY:

--- a/src/server/interface/elements.MediaProfileSpecType.kmd.json
+++ b/src/server/interface/elements.MediaProfileSpecType.kmd.json
@@ -2,13 +2,16 @@
   "complexTypes": [
     {
       "name": "MediaProfileSpecType",
-      "doc": "Media Profile.\n\nCurrently WEBM, MP4 and JPEG are supported.",
+      "doc": "Media Profile.\n\nCurrently WEBM, MKV, MP4 and JPEG are supported.",
       "typeFormat": "ENUM",
       "values": [
         "WEBM",
+        "MKV",
         "MP4",
         "WEBM_VIDEO_ONLY",
         "WEBM_AUDIO_ONLY",
+        "MKV_VIDEO_ONLY",
+        "MKV_AUDIO_ONLY",
         "MP4_VIDEO_ONLY",
         "MP4_AUDIO_ONLY",
         "JPEG_VIDEO_ONLY",


### PR DESCRIPTION
This adds `matroska` container support for the `RecorderEndpoint`, which allows us to record in a format that is a bit less corruption-prone than MP4. This also allows the media server to produce  varying-size stream recordings (like application screen sharing with window resizing).

The client APIs **must be rebuilt** to include the MKV symbols required for the `RecorderEndpoint` to identify the MKV profile. This goes to both the Java and JavaScript APIs.

This should be evaluted with a sibling pull request opened in the `kms-core` component (https://github.com/Kurento/kms-core/pull/14).