### PR TITLE
Added port-range property to PlayerEndpoint

### DIFF
--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -1100,8 +1100,8 @@ kms_player_endpoint_class_init (KmsPlayerEndpointClass * klass)
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY));
 
   g_object_class_install_property (gobject_class, PROP_PORT_RANGE,
-      g_param_spec_string ("port-range", "UDP Port range for RTSP source",
-          "When using rtsp sources, what range of UDP ports can be allocated",
+      g_param_spec_string ("port-range", "UDP Port range for RTSP client",
+          "Range of ports that can be allocated when acting as RTSP client",
           PORT_RANGE_DEFAULT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_PIPELINE,

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -353,9 +353,6 @@ kms_player_endpoint_dispose (GObject * object)
     self->priv->pipeline = NULL;
   }
 
-  g_free (self->priv->port_range);
-  self->priv->port_range = NULL;
-
   /* clean up as possible. May be called multiple times */
 
   G_OBJECT_CLASS (kms_player_endpoint_parent_class)->dispose (object);

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -353,6 +353,9 @@ kms_player_endpoint_dispose (GObject * object)
     self->priv->pipeline = NULL;
   }
 
+  g_free (self->priv->port_range);
+  self->priv->port_range = NULL;
+
   /* clean up as possible. May be called multiple times */
 
   G_OBJECT_CLASS (kms_player_endpoint_parent_class)->dispose (object);
@@ -368,6 +371,9 @@ kms_player_endpoint_finalize (GObject * object)
   g_mutex_clear (&self->priv->base_time_mutex);
   g_clear_object (&self->priv->stats.src);
   kms_list_unref (self->priv->stats.probes);
+
+  g_free (self->priv->port_range);
+  self->priv->port_range = NULL;
 
   G_OBJECT_CLASS (kms_player_endpoint_parent_class)->finalize (object);
 }

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -45,6 +45,7 @@ G_DEFINE_QUARK (APPSINK_KEY, appsink);
 G_DEFINE_QUARK (PTS_KEY, pts);
 
 #define NETWORK_CACHE_DEFAULT 2000
+#define PORT_RANGE_DEFAULT NULL
 #define IS_PREROLL TRUE
 
 GST_DEBUG_CATEGORY_STATIC (kms_player_endpoint_debug_category);
@@ -83,6 +84,7 @@ struct _KmsPlayerEndpointPrivate
   KmsLoop *loop;
   gboolean use_encoded_media;
   gint network_cache;
+  gchar *port_range;
 
   GMutex base_time_mutex;
   gboolean reset;
@@ -99,6 +101,7 @@ enum
   PROP_VIDEO_DATA,
   PROP_POSITION,
   PROP_NETWORK_CACHE,
+  PROP_PORT_RANGE,
   PROP_PIPELINE,
   N_PROPERTIES
 };
@@ -194,6 +197,10 @@ kms_player_endpoint_set_property (GObject * object, guint property_id,
     case PROP_NETWORK_CACHE:
       playerendpoint->priv->network_cache = g_value_get_int (value);
       break;
+    case PROP_PORT_RANGE:
+      g_free (playerendpoint->priv->port_range);
+      playerendpoint->priv->port_range = g_value_dup_string (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -266,6 +273,9 @@ kms_player_endpoint_get_property (GObject * object, guint property_id,
       break;
     case PROP_NETWORK_CACHE:
       g_value_set_int (value, playerendpoint->priv->network_cache);
+      break;
+    case PROP_PORT_RANGE:
+      g_value_set_string (value, playerendpoint->priv->port_range);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -1089,6 +1099,11 @@ kms_player_endpoint_class_init (KmsPlayerEndpointClass * klass)
           0, G_MAXINT, NETWORK_CACHE_DEFAULT,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY));
 
+  g_object_class_install_property (gobject_class, PROP_PORT_RANGE,
+      g_param_spec_string ("port-range", "UDP Port range for RTSP source",
+          "When using rtsp sources, what range of UDP ports can be allocated",
+          PORT_RANGE_DEFAULT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   g_object_class_install_property (gobject_class, PROP_PIPELINE,
       g_param_spec_object ("pipeline", "Internal pipeline",
           "PlayerEndpoint's private pipeline",
@@ -1272,8 +1287,11 @@ kms_player_endpoint_uridecodebin_element_added (GstBin * bin,
 
   if (g_strcmp0 (gst_plugin_feature_get_name (GST_PLUGIN_FEATURE
               (gst_element_get_factory (element))), RTSPSRC) == 0) {
-    g_object_set (G_OBJECT (element), "latency", self->priv->network_cache,
-        "drop-on-latency", TRUE, NULL);
+    g_object_set (G_OBJECT (element), 
+        "latency", self->priv->network_cache,
+        "drop-on-latency", TRUE, 
+        "port-range", self->priv->port_range,
+        NULL);
   }
 }
 
@@ -1343,6 +1361,7 @@ kms_player_endpoint_init (KmsPlayerEndpoint * self)
   self->priv->uridecodebin =
       gst_element_factory_make ("uridecodebin", NULL);
   self->priv->network_cache = NETWORK_CACHE_DEFAULT;
+  self->priv->port_range = PORT_RANGE_DEFAULT;
 
   self->priv->stats.probes = kms_list_new_full (g_direct_equal, g_object_unref,
       (GDestroyNotify) kms_stats_probe_destroy);

--- a/src/server/config/PlayerEndpoint.conf.ini
+++ b/src/server/config/PlayerEndpoint.conf.ini
@@ -1,0 +1,3 @@
+;; This is setting from gstreamer plugin gst-plugins-good
+;; https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-good/html/gst-plugins-good-plugins-rtspsrc.html#GstRTSPSrc--port-range
+;rtspSrcPortRange=<PortMin-PortMax>

--- a/src/server/config/PlayerEndpoint.conf.ini
+++ b/src/server/config/PlayerEndpoint.conf.ini
@@ -1,3 +1,2 @@
-;; This is setting from gstreamer plugin gst-plugins-good
-;; https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-good/html/gst-plugins-good-plugins-rtspsrc.html#GstRTSPSrc--port-range
-;rtspSrcPortRange=<PortMin-PortMax>
+;; Range of ports that can be allocated when acting as RTSP client
+;rtspClientPortRange=<PortMin-PortMax>

--- a/src/server/implementation/objects/PlayerEndpointImpl.cpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.cpp
@@ -36,7 +36,7 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define PIPELINE "pipeline"
 #define SET_POSITION "set-position"
 #define NS_TO_MS 1000000
-#define RTSP_SRC_PORT_RANGE "rtspSrcPortRange"
+#define RTSP_CLIENT_PORT_RANGE "rtspClientPortRange"
 
 namespace kurento
 {
@@ -109,10 +109,10 @@ PlayerEndpointImpl::PlayerEndpointImpl (const boost::property_tree::ptree &conf,
                 "network-cache", networkCache, NULL);
 
   try {
-    std::string portRange = getConfigValue <std::string, PlayerEndpoint> (RTSP_SRC_PORT_RANGE);
+    std::string portRange = getConfigValue <std::string, PlayerEndpoint> (RTSP_CLIENT_PORT_RANGE);
     g_object_set (G_OBJECT (element), "port-range", portRange.c_str(), NULL);
   } catch (boost::property_tree::ptree_error &) {
-    GST_DEBUG ("PlayerEndpoint config file doesn't contain property %s. Ignoring.", RTSP_SRC_PORT_RANGE);
+    GST_DEBUG ("PlayerEndpoint config file doesn't contain property %s. Ignoring.", RTSP_CLIENT_PORT_RANGE);
   }
 }
 

--- a/src/server/implementation/objects/PlayerEndpointImpl.cpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.cpp
@@ -36,6 +36,7 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define PIPELINE "pipeline"
 #define SET_POSITION "set-position"
 #define NS_TO_MS 1000000
+#define RTSP_SRC_PORT_RANGE "rtspSrcPortRange"
 
 namespace kurento
 {
@@ -106,6 +107,13 @@ PlayerEndpointImpl::PlayerEndpointImpl (const boost::property_tree::ptree &conf,
 
   g_object_set (G_OBJECT (element), "use-encoded-media", useEncodedMedia,
                 "network-cache", networkCache, NULL);
+
+  try {
+    std::string portRange = getConfigValue <std::string, PlayerEndpoint> (RTSP_SRC_PORT_RANGE);
+    g_object_set (G_OBJECT (element), "port-range", portRange.c_str(), NULL);
+  } catch (boost::property_tree::ptree_error &) {
+    GST_DEBUG ("PlayerEndpoint config file doesn't contain property %s. Ignoring.", RTSP_SRC_PORT_RANGE);
+  }
 }
 
 PlayerEndpointImpl::~PlayerEndpointImpl()


### PR DESCRIPTION
This PR resolves issue Kurento/bugtracker#310

It has new config file **PlayerEndpoint.conf.ini**
with one property which is currently commented out **rtspSrcPortRange**
This new property defines port range for streaming from RTSP source and restricts Kurento to using only ports within that range.

For example, if you put
rtspSrcPortRange=30000-30012
Kurento PlayerEndpoint will be restricted to use only ports from that range.
This is useful if you want to implement stricter firewall rules.