### PR TITLE
Fix MediaFlowInStateChange crash: Lock mutex around calls to sigc++

### DIFF
--- a/src/server/implementation/objects/HttpEndpointImpl.cpp
+++ b/src/server/implementation/objects/HttpEndpointImpl.cpp
@@ -251,6 +251,7 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
 
         GST_ERROR ("%s", errorMessage.c_str() );
 
+        std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
         signalError (error);
       } catch (std::bad_weak_ptr &e) {
       }
@@ -259,6 +260,7 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
         MediaSessionStarted event (shared_from_this(),
                                    MediaSessionStarted::getName() );
 
+        std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
         signalMediaSessionStarted (event);
       } catch (std::bad_weak_ptr &e) {
       }
@@ -310,6 +312,7 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
       MediaSessionTerminated event (shared_from_this(),
                                     MediaSessionTerminated::getName() );
 
+      std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
       signalMediaSessionTerminated (event);
     } catch (std::bad_weak_ptr &e) {
     }

--- a/src/server/implementation/objects/HttpEndpointImpl.cpp
+++ b/src/server/implementation/objects/HttpEndpointImpl.cpp
@@ -247,12 +247,11 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
       std::string errorMessage = "Invalid or unexpected request received";
 
       try {
-        Error error (shared_from_this(), "Invalid URI", 0, "INVALID_URI");
+        Error event (shared_from_this(), "Invalid URI", 0, "INVALID_URI");
 
         GST_ERROR ("%s", errorMessage.c_str() );
 
-        std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-        signalError (error);
+        sigcSignalEmit(signalError, event);
       } catch (std::bad_weak_ptr &e) {
       }
     } else {
@@ -260,8 +259,7 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
         MediaSessionStarted event (shared_from_this(),
                                    MediaSessionStarted::getName() );
 
-        std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-        signalMediaSessionStarted (event);
+        sigcSignalEmit(signalMediaSessionStarted, event);
       } catch (std::bad_weak_ptr &e) {
       }
     }
@@ -312,8 +310,7 @@ HttpEndpointImpl::HttpEndpointImpl (const boost::property_tree::ptree &conf,
       MediaSessionTerminated event (shared_from_this(),
                                     MediaSessionTerminated::getName() );
 
-      std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-      signalMediaSessionTerminated (event);
+      sigcSignalEmit(signalMediaSessionTerminated, event);
     } catch (std::bad_weak_ptr &e) {
     }
   };

--- a/src/server/implementation/objects/HttpPostEndpointImpl.cpp
+++ b/src/server/implementation/objects/HttpPostEndpointImpl.cpp
@@ -39,6 +39,7 @@ void HttpPostEndpointImpl::eosLambda ()
   try {
     EndOfStream event (shared_from_this(), EndOfStream::getName() );
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalEndOfStream (event);
   } catch (std::bad_weak_ptr &e) {
   }

--- a/src/server/implementation/objects/HttpPostEndpointImpl.cpp
+++ b/src/server/implementation/objects/HttpPostEndpointImpl.cpp
@@ -39,8 +39,7 @@ void HttpPostEndpointImpl::eosLambda ()
   try {
     EndOfStream event (shared_from_this(), EndOfStream::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalEndOfStream (event);
+    sigcSignalEmit(signalEndOfStream, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }

--- a/src/server/implementation/objects/PlayerEndpointImpl.cpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.cpp
@@ -45,6 +45,7 @@ void PlayerEndpointImpl::eosHandler ()
   try {
     EndOfStream event (shared_from_this(), EndOfStream::getName() );
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalEndOfStream (event);
   } catch (std::bad_weak_ptr &e) {
   }
@@ -56,6 +57,7 @@ void PlayerEndpointImpl::invalidUri ()
     /* TODO: Define error codes and types*/
     Error error (shared_from_this(), "Invalid URI", 0, "INVALID_URI");
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalError (error);
   } catch (std::bad_weak_ptr &e) {
   }
@@ -67,6 +69,7 @@ void PlayerEndpointImpl::invalidMedia ()
     /* TODO: Define error codes and types*/
     Error error (shared_from_this(), "Invalid Media", 0, "INVALID_MEDIA");
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalError (error);
   } catch (std::bad_weak_ptr &e) {
   }

--- a/src/server/implementation/objects/PlayerEndpointImpl.cpp
+++ b/src/server/implementation/objects/PlayerEndpointImpl.cpp
@@ -45,8 +45,7 @@ void PlayerEndpointImpl::eosHandler ()
   try {
     EndOfStream event (shared_from_this(), EndOfStream::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalEndOfStream (event);
+    sigcSignalEmit(signalEndOfStream, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -55,10 +54,9 @@ void PlayerEndpointImpl::invalidUri ()
 {
   try {
     /* TODO: Define error codes and types*/
-    Error error (shared_from_this(), "Invalid URI", 0, "INVALID_URI");
+    Error event (shared_from_this(), "Invalid URI", 0, "INVALID_URI");
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalError (error);
+    sigcSignalEmit(signalError, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -67,10 +65,9 @@ void PlayerEndpointImpl::invalidMedia ()
 {
   try {
     /* TODO: Define error codes and types*/
-    Error error (shared_from_this(), "Invalid Media", 0, "INVALID_MEDIA");
+    Error event (shared_from_this(), "Invalid Media", 0, "INVALID_MEDIA");
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalError (error);
+    sigcSignalEmit(signalError, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }

--- a/src/server/implementation/objects/RecorderEndpointImpl.cpp
+++ b/src/server/implementation/objects/RecorderEndpointImpl.cpp
@@ -167,6 +167,8 @@ RecorderEndpointImpl::onStateChanged (gint newState)
   case KMS_URI_END_POINT_STATE_STOP: {
     GST_DEBUG_OBJECT (element, "State changed to Stopped");
     Stopped event (shared_from_this(), Stopped::getName() );
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalStopped (event);
     break;
   }
@@ -174,6 +176,8 @@ RecorderEndpointImpl::onStateChanged (gint newState)
   case KMS_URI_END_POINT_STATE_START: {
     GST_DEBUG_OBJECT (element, "State changed to Recording");
     Recording event (shared_from_this(), Recording::getName() );
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalRecording (event);
     break;
   }
@@ -181,6 +185,8 @@ RecorderEndpointImpl::onStateChanged (gint newState)
   case KMS_URI_END_POINT_STATE_PAUSE: {
     GST_DEBUG_OBJECT (element, "State changed to Paused");
     Paused event (shared_from_this(), Paused::getName() );
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalPaused (event);
     break;
   }

--- a/src/server/implementation/objects/RecorderEndpointImpl.cpp
+++ b/src/server/implementation/objects/RecorderEndpointImpl.cpp
@@ -168,8 +168,7 @@ RecorderEndpointImpl::onStateChanged (gint newState)
     GST_DEBUG_OBJECT (element, "State changed to Stopped");
     Stopped event (shared_from_this(), Stopped::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalStopped (event);
+    sigcSignalEmit(signalStopped, event);
     break;
   }
 
@@ -177,8 +176,7 @@ RecorderEndpointImpl::onStateChanged (gint newState)
     GST_DEBUG_OBJECT (element, "State changed to Recording");
     Recording event (shared_from_this(), Recording::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalRecording (event);
+    sigcSignalEmit(signalRecording, event);
     break;
   }
 
@@ -186,8 +184,7 @@ RecorderEndpointImpl::onStateChanged (gint newState)
     GST_DEBUG_OBJECT (element, "State changed to Paused");
     Paused event (shared_from_this(), Paused::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalPaused (event);
+    sigcSignalEmit(signalPaused, event);
     break;
   }
   }

--- a/src/server/implementation/objects/RtpEndpointImpl.cpp
+++ b/src/server/implementation/objects/RtpEndpointImpl.cpp
@@ -150,6 +150,8 @@ RtpEndpointImpl::onKeySoftLimit (gchar *media)
 
   try {
     OnKeySoftLimit event (shared_from_this(), OnKeySoftLimit::getName(), type);
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnKeySoftLimit (event);
   } catch (std::bad_weak_ptr &e) {
   }

--- a/src/server/implementation/objects/RtpEndpointImpl.cpp
+++ b/src/server/implementation/objects/RtpEndpointImpl.cpp
@@ -151,8 +151,7 @@ RtpEndpointImpl::onKeySoftLimit (gchar *media)
   try {
     OnKeySoftLimit event (shared_from_this(), OnKeySoftLimit::getName(), type);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnKeySoftLimit (event);
+    sigcSignalEmit(signalOnKeySoftLimit, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -189,6 +189,7 @@ void WebRtcEndpointImpl::onIceCandidate (gchar *sessId,
     IceCandidateFound newEvent (shared_from_this(), IceCandidateFound::getName(),
                                 cand);
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnIceCandidate (event);
     signalIceCandidateFound (newEvent);
   } catch (std::bad_weak_ptr &e) {
@@ -201,6 +202,7 @@ void WebRtcEndpointImpl::onIceGatheringDone (gchar *sessId)
     OnIceGatheringDone event (shared_from_this(), OnIceGatheringDone::getName() );
     IceGatheringDone newEvent (shared_from_this(), IceGatheringDone::getName() );
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnIceGatheringDone (event);
     signalIceGatheringDone (newEvent);
   } catch (std::bad_weak_ptr &e) {
@@ -269,6 +271,7 @@ void WebRtcEndpointImpl::onIceComponentStateChanged (gchar *sessId,
     iceConnectionState.insert (std::pair
                                <std::string, std::shared_ptr <IceConnection>> (key, connectionState) );
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnIceComponentStateChanged (event);
     signalIceComponentStateChange (newEvent);
   } catch (std::bad_weak_ptr &e) {
@@ -310,6 +313,7 @@ void WebRtcEndpointImpl::newSelectedPairFull (gchar *sessId,
     NewCandidatePairSelected event (shared_from_this(),
                                     NewCandidatePairSelected::getName(), candidatePair);
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalNewCandidatePairSelected (event);
   } catch (std::bad_weak_ptr &e) {
   }
@@ -323,6 +327,8 @@ WebRtcEndpointImpl::onDataChannelOpened (gchar *sessId, guint stream_id)
                                stream_id);
     DataChannelOpen newEvent (shared_from_this(), DataChannelOpen::getName(),
                               stream_id);
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnDataChannelOpened (event);
     signalDataChannelOpen (newEvent);
   } catch (std::bad_weak_ptr &e) {
@@ -337,6 +343,8 @@ WebRtcEndpointImpl::onDataChannelClosed (gchar *sessId, guint stream_id)
                                stream_id);
     DataChannelClose newEvent (shared_from_this(), DataChannelClose::getName(),
                                stream_id);
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalOnDataChannelClosed (event);
     signalDataChannelClose (newEvent);
   } catch (std::bad_weak_ptr &e) {

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -189,9 +189,8 @@ void WebRtcEndpointImpl::onIceCandidate (gchar *sessId,
     IceCandidateFound newEvent (shared_from_this(), IceCandidateFound::getName(),
                                 cand);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnIceCandidate (event);
-    signalIceCandidateFound (newEvent);
+    sigcSignalEmit(signalOnIceCandidate, event);
+    sigcSignalEmit(signalIceCandidateFound, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -202,9 +201,8 @@ void WebRtcEndpointImpl::onIceGatheringDone (gchar *sessId)
     OnIceGatheringDone event (shared_from_this(), OnIceGatheringDone::getName() );
     IceGatheringDone newEvent (shared_from_this(), IceGatheringDone::getName() );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnIceGatheringDone (event);
-    signalIceGatheringDone (newEvent);
+    sigcSignalEmit(signalOnIceGatheringDone, event);
+    sigcSignalEmit(signalIceGatheringDone, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -271,9 +269,8 @@ void WebRtcEndpointImpl::onIceComponentStateChanged (gchar *sessId,
     iceConnectionState.insert (std::pair
                                <std::string, std::shared_ptr <IceConnection>> (key, connectionState) );
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnIceComponentStateChanged (event);
-    signalIceComponentStateChange (newEvent);
+    sigcSignalEmit(signalOnIceComponentStateChanged, event);
+    sigcSignalEmit(signalIceComponentStateChange, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -313,8 +310,7 @@ void WebRtcEndpointImpl::newSelectedPairFull (gchar *sessId,
     NewCandidatePairSelected event (shared_from_this(),
                                     NewCandidatePairSelected::getName(), candidatePair);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalNewCandidatePairSelected (event);
+    sigcSignalEmit(signalNewCandidatePairSelected, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -328,9 +324,8 @@ WebRtcEndpointImpl::onDataChannelOpened (gchar *sessId, guint stream_id)
     DataChannelOpen newEvent (shared_from_this(), DataChannelOpen::getName(),
                               stream_id);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnDataChannelOpened (event);
-    signalDataChannelOpen (newEvent);
+    sigcSignalEmit(signalOnDataChannelOpened, event);
+    sigcSignalEmit(signalDataChannelOpen, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -344,9 +339,8 @@ WebRtcEndpointImpl::onDataChannelClosed (gchar *sessId, guint stream_id)
     DataChannelClose newEvent (shared_from_this(), DataChannelClose::getName(),
                                stream_id);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalOnDataChannelClosed (event);
-    signalDataChannelClose (newEvent);
+    sigcSignalEmit(signalOnDataChannelClosed, event);
+    sigcSignalEmit(signalDataChannelClose, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }


### PR DESCRIPTION
libsigc++ signal/slot mechanism is *not thread-safe*. All signal emitters must coordinate with a mutex, or else multiple threads might try to emit at the same time, breaking the library.

Repos:
* Kurento/kms-core#19
* Kurento/kms-elements#19
* Kurento/kms-filters#4