### PR TITLE
Feat/vaapi enc

### DIFF
--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -1066,7 +1066,7 @@ kms_player_endpoint_class_init (KmsPlayerEndpointClass * klass)
   // the `uridecodebin`
   GstRegistry* registry = gst_registry_get();
   GstPluginFeature* vaapidecodebin = gst_registry_lookup_feature(registry, "vaapidecodebin");
-  if(vaapidecodebin == NULL) {
+  if(vaapidecodebin != NULL) {
     gst_plugin_feature_set_rank(vaapidecodebin, GST_RANK_NONE);
     gst_object_unref(vaapidecodebin);
   }

--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -1060,6 +1060,17 @@ kms_player_endpoint_collect_media_stats (KmsElement * obj, gboolean enable)
 static void
 kms_player_endpoint_class_init (KmsPlayerEndpointClass * klass)
 {
+  // make sure `vaapidecodebin` is not used
+  // this is required when VAAPI elements are installed, as it breaks the pipeline
+  // VAAPI decoding works in general, but does not seem to do so in combination with
+  // the `uridecodebin`
+  GstRegistry* registry = gst_registry_get();
+  GstPluginFeature* vaapidecodebin = gst_registry_lookup_feature(registry, "vaapidecodebin");
+  if(vaapidecodebin == NULL) {
+    gst_plugin_feature_set_rank(vaapidecodebin, GST_RANK_NONE);
+    gst_object_unref(vaapidecodebin);
+  }
+
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   KmsElementClass *kms_element_class = KMS_ELEMENT_CLASS (klass);
   KmsUriEndpointClass *urienpoint_class = KMS_URI_ENDPOINT_CLASS (klass);


### PR DESCRIPTION
This corresponds to [PR 21 in kms-core](https://github.com/Kurento/kms-core/pull/21).

It makes sure `vaapidecodebin` is not used when GStreamer `vaapi` elements are installed (see issue [#392](https://github.com/Kurento/bugtracker/issues/392))

As an FYI: There does not seem to be an issue with `vaapidecode` in general, at least everything works fine when 

* the `uridecodebin` is replaced by a dedicated pipeline consisting of `rtspsrc` and `vaapih264dec`
* `uridecodebin` is used from a plain GStreamer pipeline (e.g. `gst-launch1.0 uridecodebin url="rtsp://..." ! vaapih264enc ! avdec_h264 ! autovideosink`)