### PR TITLE
Fix  STUN server usage when stunServerPort isn't set and the default value is to be used

### DIFF
--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -533,23 +533,25 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
   }
 
   uint stunPort = 0;
+
   if (!getConfigValue <uint, WebRtcEndpoint> (&stunPort, "stunServerPort",
-      DEFAULT_STUN_PORT)) {
+      DEFAULT_STUN_PORT) ) {
     GST_INFO ("STUN port not found in config;"
               " using default value: %d", DEFAULT_STUN_PORT);
-  } else {
-    std::string stunAddress;
-    if (!getConfigValue <std::string, WebRtcEndpoint> (&stunAddress,
-        "stunServerAddress")) {
-      GST_INFO ("STUN server not found in config;"
-                " remember that NAT traversal requires STUN or TURN");
-    } else {
-      GST_INFO ("Using STUN reflexive server: %s:%d", stunAddress.c_str(),
-          stunPort);
+  }
 
-      g_object_set (G_OBJECT (element), "stun-server-port", stunPort, NULL);
-      g_object_set (G_OBJECT (element), "stun-server", stunAddress.c_str(), NULL);
-    }
+  std::string stunAddress;
+
+  if (!getConfigValue <std::string, WebRtcEndpoint> (&stunAddress,
+      "stunServerAddress") ) {
+    GST_INFO ("STUN server not found in config;"
+              " remember that NAT traversal requires STUN or TURN");
+  } else {
+    GST_INFO ("Using STUN reflexive server: %s:%d", stunAddress.c_str(),
+              stunPort);
+
+    g_object_set (G_OBJECT (element), "stun-server-port", stunPort, NULL);
+    g_object_set (G_OBJECT (element), "stun-server", stunAddress.c_str(), NULL);
   }
 
   std::string turnURL;


### PR DESCRIPTION
## What is the current behavior you want to change?
The `stunServerPort` configuration in `WebRtcEndpoint.conf.ini` is supposed to be an optional one since there's a DEFAULT_STUN_PORT (3478) set up in WebRtcEndpointImpl.cpp. 

**Expected behaviour**: be able to configure only `stunServerAddress` if the STUN server's port is the default one (3478). 

**Current behaviour**: if `stunServerPort` isn't configured and `stunServerAddress` is, Kurento will not set a STUN server in the NiceAgent due to a botched pair of if-else blocks in WebRtcEndpointImpl.cpp.


## What is the new behavior provided by this change?
Configuring only `stunServerAddress` in WebRtcEndpoint.conf.ini will make KMS configure a STUN server in the NiceAgent interface with the default STUN port (3478).


## How has this been tested?
Tested with the following variation of the `stunServerAddress`/`stunServerPort` configs:
  - No `stunServerPort`, with `stunServerAddress` -> STUN server set in WebRtcEndpoint with `$stunServerAddress:3478`
  - With `stunServerAddress and `stunServerPort`: STUN server set in WebRtcEndpoint with `$stunServerAddress:stunServerPort`
  - With `stunServerPort`, no `stunServerAddress` -> No STUN server set in WebRtcEndpoint
  - No `stunServerPort`, no `stunServerAddress` -> No STUN server set in WebRtcEndpoint

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
