### PR TITLE
Fix incorrect cropping in AlphaBlending element

### DIFF
--- a/src/gst-plugins/kmsalphablending.c
+++ b/src/gst-plugins/kmsalphablending.c
@@ -204,22 +204,14 @@ configure_port (KmsAlphaBlendingData * port_data)
       int top = 0;
       int bottom = 0;
 
-      if (_relative_x > 0) {
-        int width_size =
-            (mixer->priv->output_width - (mixer->priv->output_width -
-                _relative_x));
-      } else {
+      if (_relative_x <= 0) {
         left = -1 * _relative_x;
         if ((_relative_width - left) > mixer->priv->output_width) {
           right = (_relative_width - left) - mixer->priv->output_width;
         }
       }
 
-      if (_relative_y > 0) {
-        int height_size =
-            (mixer->priv->output_height - (mixer->priv->output_height -
-                _relative_y));
-      } else {
+      if (_relative_y <= 0) {
         top = -1 * _relative_y;
         if ((_relative_height - top) > mixer->priv->output_height) {
           bottom = (_relative_height - top) - mixer->priv->output_height;

--- a/src/gst-plugins/kmsalphablending.c
+++ b/src/gst-plugins/kmsalphablending.c
@@ -208,9 +208,6 @@ configure_port (KmsAlphaBlendingData * port_data)
         int width_size =
             (mixer->priv->output_width - (mixer->priv->output_width -
                 _relative_x));
-        if (_relative_width > width_size) {
-          right = (_relative_width - width_size);
-        }
       } else {
         left = -1 * _relative_x;
         if ((_relative_width - left) > mixer->priv->output_width) {
@@ -222,9 +219,6 @@ configure_port (KmsAlphaBlendingData * port_data)
         int height_size =
             (mixer->priv->output_height - (mixer->priv->output_height -
                 _relative_y));
-        if (_relative_height > height_size) {
-          bottom = (_relative_height - height_size);
-        }
       } else {
         top = -1 * _relative_y;
         if ((_relative_height - top) > mixer->priv->output_height) {


### PR DESCRIPTION
## What is the current behavior you want to change?
When the relative X/Y is greater than zero but less than the relative width/height, the video is cropped incorrectly.
Fixes https://github.com/Kurento/bugtracker/issues/63.

ie) Given `setPortProperties(0.1, 0.1, 0, 0.5, 0.5, port)` results in the video being positioned at 0.1, 0.1 but only a small slice of the video is showing, the rest is cropped.

## What is the new behavior provided by this change?
Removing this cropping produces the expected behaviour with correct relative X, Y, width, height.

ie) Given `setPortProperties(0.1, 0.1, 0, 0.5, 0.5, port)` results in the video being positioned at 0.1, 0.1 with the entire video showing, correctly scaled to 50% of the master port size.

## How has this been tested?
Tested in Ubuntu 18 with both latest KMS source and as a module in KMS 6.14.1 installed through apt.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->

## Checklist
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have written new tests for the changes, as applicable, and have successfully run them locally
