### PR TITLE
Add niceAgentIceTcp configuration option and API methods for it

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
@@ -254,6 +254,17 @@ kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
 }
 
 void
+kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
+    self, gboolean niceAgentIceTcp)
+{
+  if (KMS_IS_ICE_NICE_AGENT (self->agent)) {
+    KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self->agent);
+    g_object_set (kms_ice_nice_agent_get_agent (nice_agent),
+        "ice-tcp", niceAgentIceTcp, NULL);
+  }
+}
+
+void
 kms_webrtc_base_connection_set_stun_server_info (KmsWebRtcBaseConnection * self,
     const gchar * ip, guint port)
 {

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
@@ -254,13 +254,13 @@ kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
 }
 
 void
-kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
-    self, gboolean niceAgentIceTcp)
+kms_webrtc_base_connection_set_ice_tcp (KmsWebRtcBaseConnection *self,
+    gboolean ice_tcp)
 {
   if (KMS_IS_ICE_NICE_AGENT (self->agent)) {
     KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self->agent);
-    g_object_set (kms_ice_nice_agent_get_agent (nice_agent),
-        "ice-tcp", niceAgentIceTcp, NULL);
+    g_object_set (
+        kms_ice_nice_agent_get_agent (nice_agent), "ice-tcp", ice_tcp, NULL);
   }
 }
 

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
@@ -81,6 +81,8 @@ gchar *kms_webrtc_base_connection_get_certificate_pem (KmsWebRtcBaseConnection *
     self);
 void kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
     self, const gchar * net_names);
+void kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
+    self, gboolean niceAgenIceTcp);
 void kms_webrtc_base_connection_set_stun_server_info (KmsWebRtcBaseConnection * self,
     const gchar * stun_server_ip, guint stun_server_port);
 void kms_webrtc_base_connection_set_relay_info (KmsWebRtcBaseConnection * self,

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
@@ -81,8 +81,8 @@ gchar *kms_webrtc_base_connection_get_certificate_pem (KmsWebRtcBaseConnection *
     self);
 void kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
     self, const gchar * net_names);
-void kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
-    self, gboolean niceAgenIceTcp);
+void kms_webrtc_base_connection_set_ice_tcp (KmsWebRtcBaseConnection *self,
+    gboolean ice_tcp);
 void kms_webrtc_base_connection_set_stun_server_info (KmsWebRtcBaseConnection * self,
     const gchar * stun_server_ip, guint stun_server_port);
 void kms_webrtc_base_connection_set_relay_info (KmsWebRtcBaseConnection * self,

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
@@ -58,7 +58,7 @@ G_DEFINE_TYPE (KmsWebrtcEndpoint, kms_webrtc_endpoint,
 #define DEFAULT_EXTERNAL_ADDRESS NULL
 #define DEFAULT_EXTERNAL_IPV4 NULL
 #define DEFAULT_EXTERNAL_IPV6 NULL
-#define DEFAULT_NICEAGENT_ICE_TCP TRUE
+#define DEFAULT_ICE_TCP TRUE
 
 enum
 {
@@ -71,7 +71,7 @@ enum
   PROP_EXTERNAL_ADDRESS,
   PROP_EXTERNAL_IPV4,
   PROP_EXTERNAL_IPV6,
-  PROP_NICEAGENT_ICE_TCP,
+  PROP_ICE_TCP,
   N_PROPERTIES
 };
 
@@ -107,7 +107,7 @@ struct _KmsWebrtcEndpointPrivate
   gchar *external_address;
   gchar *external_ipv4;
   gchar *external_ipv6;
-  gboolean niceagent_ice_tcp;
+  gboolean ice_tcp;
 };
 
 /* Internal session management begin */
@@ -342,8 +342,8 @@ kms_webrtc_endpoint_create_session_internal (KmsBaseSdpEndpoint * base_sdp,
       webrtc_sess, "external-ipv4", G_BINDING_DEFAULT);
   g_object_bind_property (self, "external-ipv6",
       webrtc_sess, "external-ipv6", G_BINDING_DEFAULT);
-  g_object_bind_property (self, "niceagent-ice-tcp",
-      webrtc_sess, "niceagent-ice-tcp", G_BINDING_DEFAULT);
+  g_object_bind_property (self, "ice-tcp",
+      webrtc_sess, "ice-tcp", G_BINDING_DEFAULT);
 
   g_object_set (webrtc_sess, "stun-server", self->priv->stun_server_ip,
       "stun-server-port", self->priv->stun_server_port,
@@ -353,7 +353,8 @@ kms_webrtc_endpoint_create_session_internal (KmsBaseSdpEndpoint * base_sdp,
       "external-address", self->priv->external_address,
       "external-ipv4", self->priv->external_ipv4,
       "external-ipv6", self->priv->external_ipv6,
-      "niceagent-ice-tcp", self->priv->niceagent_ice_tcp, NULL);
+      "ice-tcp", self->priv->ice_tcp,
+      NULL);
 
   g_signal_connect (webrtc_sess, "on-ice-candidate",
       G_CALLBACK (on_ice_candidate), self);
@@ -537,8 +538,8 @@ kms_webrtc_endpoint_set_property (GObject * object, guint prop_id,
       g_free (self->priv->external_ipv6);
       self->priv->external_ipv6 = g_value_dup_string (value);
       break;
-    case PROP_NICEAGENT_ICE_TCP:
-      self->priv->niceagent_ice_tcp = g_value_get_boolean (value);
+    case PROP_ICE_TCP:
+      self->priv->ice_tcp = g_value_get_boolean (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -581,8 +582,8 @@ kms_webrtc_endpoint_get_property (GObject * object, guint prop_id,
     case PROP_EXTERNAL_IPV6:
       g_value_set_string (value, self->priv->external_ipv6);
       break;
-    case PROP_NICEAGENT_ICE_TCP:
-      g_value_set_boolean (value, self->priv->niceagent_ice_tcp);
+    case PROP_ICE_TCP:
+      g_value_set_boolean (value, self->priv->ice_tcp);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -823,11 +824,11 @@ kms_webrtc_endpoint_class_init (KmsWebrtcEndpointClass * klass)
           "External (public) IPv6 address of the media server",
           DEFAULT_EXTERNAL_IPV6, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_NICEAGENT_ICE_TCP,
-      g_param_spec_boolean ("niceagent-ice-tcp",
-        "niceAgentIceTcp",
-        "Enable NiceAgent's ICE-TCP gathering",
-        DEFAULT_NICEAGENT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_ICE_TCP,
+      g_param_spec_boolean ("ice-tcp",
+        "iceTcp",
+        "Enable ICE-TCP candidate gathering",
+        DEFAULT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   /**
   * KmsWebrtcEndpoint::on-ice-candidate:
@@ -965,7 +966,7 @@ kms_webrtc_endpoint_init (KmsWebrtcEndpoint * self)
   self->priv->external_address = DEFAULT_EXTERNAL_ADDRESS;
   self->priv->external_ipv4 = DEFAULT_EXTERNAL_IPV4;
   self->priv->external_ipv6 = DEFAULT_EXTERNAL_IPV6;
-  self->priv->niceagent_ice_tcp = DEFAULT_NICEAGENT_ICE_TCP;
+  self->priv->ice_tcp = DEFAULT_ICE_TCP;
 
   self->priv->loop = kms_loop_new ();
   g_object_get (self->priv->loop, "context", &self->priv->context, NULL);

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
@@ -58,7 +58,7 @@ G_DEFINE_TYPE (KmsWebrtcSession, kms_webrtc_session, KMS_TYPE_BASE_RTP_SESSION);
 #define DEFAULT_EXTERNAL_ADDRESS NULL
 #define DEFAULT_EXTERNAL_IPV4 NULL
 #define DEFAULT_EXTERNAL_IPV6 NULL
-#define DEFAULT_NICEAGENT_ICE_TCP TRUE
+#define DEFAULT_ICE_TCP TRUE
 
 #define IP_VERSION_6 6
 
@@ -95,7 +95,7 @@ enum
   PROP_EXTERNAL_ADDRESS,
   PROP_EXTERNAL_IPV4,
   PROP_EXTERNAL_IPV6,
-  PROP_NICEAGENT_ICE_TCP,
+  PROP_ICE_TCP,
   N_PROPERTIES
 };
 
@@ -810,12 +810,11 @@ kms_webrtc_session_set_network_ifs_info (KmsWebrtcSession * self,
 }
 
 static void
-kms_webrtc_session_set_niceagent_ice_tcp (KmsWebrtcSession * self,
-    KmsWebRtcBaseConnection * conn)
+kms_webrtc_session_set_ice_tcp (KmsWebrtcSession *self,
+    KmsWebRtcBaseConnection *conn)
 {
-  kms_webrtc_base_connection_set_agent_ice_tcp (conn, self->niceagent_ice_tcp);
+  kms_webrtc_base_connection_set_ice_tcp (conn, self->ice_tcp);
 }
-
 
 static void
 kms_webrtc_session_set_stun_server_info (KmsWebrtcSession * self,
@@ -856,7 +855,7 @@ kms_webrtc_session_gather_candidates (KmsWebrtcSession * self)
     KmsWebRtcBaseConnection *conn = KMS_WEBRTC_BASE_CONNECTION (v);
 
     kms_webrtc_session_set_network_ifs_info (self, conn);
-    kms_webrtc_session_set_niceagent_ice_tcp (self, conn);
+    kms_webrtc_session_set_ice_tcp (self, conn);
     kms_webrtc_session_set_stun_server_info (self, conn);
     kms_webrtc_session_set_relay_info (self, conn);
 
@@ -1767,8 +1766,8 @@ kms_webrtc_session_set_property (GObject * object, guint prop_id,
       g_free (self->external_ipv6);
       self->external_ipv6 = g_value_dup_string (value);
       break;
-    case PROP_NICEAGENT_ICE_TCP:
-      self->niceagent_ice_tcp = g_value_get_boolean (value);
+    case PROP_ICE_TCP:
+      self->ice_tcp = g_value_get_boolean (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -1814,8 +1813,8 @@ kms_webrtc_session_get_property (GObject * object, guint prop_id,
     case PROP_EXTERNAL_IPV6:
       g_value_set_string (value, self->external_ipv6);
       break;
-    case PROP_NICEAGENT_ICE_TCP:
-      g_value_set_boolean (value, self->niceagent_ice_tcp);
+    case PROP_ICE_TCP:
+      g_value_set_boolean (value, self->ice_tcp);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -1957,7 +1956,7 @@ kms_webrtc_session_init (KmsWebrtcSession * self)
   self->external_address = DEFAULT_EXTERNAL_ADDRESS;
   self->external_ipv4= DEFAULT_EXTERNAL_IPV4;
   self->external_ipv6 = DEFAULT_EXTERNAL_IPV6;
-  self->niceagent_ice_tcp = DEFAULT_NICEAGENT_ICE_TCP;
+  self->ice_tcp = DEFAULT_ICE_TCP;
   self->gather_started = FALSE;
 
   self->data_channels = g_hash_table_new_full (g_direct_hash,
@@ -2075,11 +2074,11 @@ kms_webrtc_session_class_init (KmsWebrtcSessionClass * klass)
           "External (public) IPv6 address of the media server",
           DEFAULT_EXTERNAL_IPV6, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_NICEAGENT_ICE_TCP,
-      g_param_spec_boolean ("niceagent-ice-tcp",
-          "niceAgentIceTcp",
-          "Enable NiceAgent's ICE-TCP gathering",
-          DEFAULT_NICEAGENT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_ICE_TCP,
+      g_param_spec_boolean ("ice-tcp",
+          "iceTcp",
+          "Enable ICE-TCP candidate gathering",
+          DEFAULT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_DATA_CHANNEL_SUPPORTED,
       g_param_spec_boolean ("data-channel-supported",

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
@@ -56,6 +56,7 @@ G_DEFINE_TYPE (KmsWebrtcSession, kms_webrtc_session, KMS_TYPE_BASE_RTP_SESSION);
 #define DEFAULT_PEM_CERTIFICATE NULL
 #define DEFAULT_NETWORK_INTERFACES NULL
 #define DEFAULT_EXTERNAL_ADDRESS NULL
+#define DEFAULT_NICEAGENT_ICE_TCP TRUE
 
 #define IP_VERSION_6 6
 
@@ -90,6 +91,7 @@ enum
   PROP_PEM_CERTIFICATE,
   PROP_NETWORK_INTERFACES,
   PROP_EXTERNAL_ADDRESS,
+  PROP_NICEAGENT_ICE_TCP,
   N_PROPERTIES
 };
 
@@ -793,6 +795,14 @@ kms_webrtc_session_set_network_ifs_info (KmsWebrtcSession * self,
 }
 
 static void
+kms_webrtc_session_set_niceagent_ice_tcp (KmsWebrtcSession * self,
+    KmsWebRtcBaseConnection * conn)
+{
+  kms_webrtc_base_connection_set_agent_ice_tcp (conn, self->niceagent_ice_tcp);
+}
+
+
+static void
 kms_webrtc_session_set_stun_server_info (KmsWebrtcSession * self,
     KmsWebRtcBaseConnection * conn)
 {
@@ -831,6 +841,7 @@ kms_webrtc_session_gather_candidates (KmsWebrtcSession * self)
     KmsWebRtcBaseConnection *conn = KMS_WEBRTC_BASE_CONNECTION (v);
 
     kms_webrtc_session_set_network_ifs_info (self, conn);
+    kms_webrtc_session_set_niceagent_ice_tcp (self, conn);
     kms_webrtc_session_set_stun_server_info (self, conn);
     kms_webrtc_session_set_relay_info (self, conn);
 
@@ -1733,6 +1744,9 @@ kms_webrtc_session_set_property (GObject * object, guint prop_id,
       g_free (self->external_address);
       self->external_address = g_value_dup_string (value);
       break;
+    case PROP_NICEAGENT_ICE_TCP:
+      self->niceagent_ice_tcp = g_value_get_boolean (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -1770,6 +1784,9 @@ kms_webrtc_session_get_property (GObject * object, guint prop_id,
       break;
     case PROP_EXTERNAL_ADDRESS:
       g_value_set_string (value, self->external_address);
+      break;
+    case PROP_NICEAGENT_ICE_TCP:
+      g_value_set_boolean (value, self->niceagent_ice_tcp);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -1907,6 +1924,7 @@ kms_webrtc_session_init (KmsWebrtcSession * self)
   self->pem_certificate = DEFAULT_PEM_CERTIFICATE;
   self->network_interfaces = DEFAULT_NETWORK_INTERFACES;
   self->external_address = DEFAULT_EXTERNAL_ADDRESS;
+  self->niceagent_ice_tcp = DEFAULT_NICEAGENT_ICE_TCP;
   self->gather_started = FALSE;
 
   self->data_channels = g_hash_table_new_full (g_direct_hash,
@@ -2011,6 +2029,12 @@ kms_webrtc_session_class_init (KmsWebrtcSessionClass * klass)
           "externalAddress",
           "External (public) IP address of the media server",
           DEFAULT_EXTERNAL_ADDRESS, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_NICEAGENT_ICE_TCP,
+      g_param_spec_boolean ("niceagent-ice-tcp",
+          "niceAgentIceTcp",
+          "Enable NiceAgent's ICE-TCP gathering",
+          DEFAULT_NICEAGENT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_DATA_CHANNEL_SUPPORTED,
       g_param_spec_boolean ("data-channel-supported",

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
@@ -72,6 +72,7 @@ struct _KmsWebrtcSession
   gchar *pem_certificate;
   gchar *network_interfaces;
   gchar *external_address;
+  gboolean niceagent_ice_tcp;
 
   guint16 min_port;
   guint16 max_port;

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
@@ -74,7 +74,7 @@ struct _KmsWebrtcSession
   gchar *external_address;
   gchar *external_ipv4;
   gchar *external_ipv6;
-  gboolean niceagent_ice_tcp;
+  gboolean ice_tcp;
 
   guint16 min_port;
   guint16 max_port;

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -102,3 +102,13 @@
 ;; externalAddress=2001:0db8:85a3:0000:0000:8a2e:0370:7334
 ;;
 ;externalAddress=10.20.30.40
+
+;; Whether to enable TCP candidate gathering via NiceAgent's ice-tcp property.
+;; The motivation behind this is to potentially speed up gathering
+;; by preventing TCP candidate gathering in scenarios where they aren't needed.
+;; Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
+;;
+;; <niceAgentIceTcp> MUST be either 0 (FALSE) or 1 (TRUE)
+;; Default is 1 (TRUE)
+;;
+;niceAgentIceTcp=1

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -133,5 +133,4 @@
 ;; <niceAgentIceTcp> MUST be either 0 (FALSE) or 1 (TRUE)
 ;; Default is 1 (TRUE)
 ;;
-;niceAgentIceTcp=1
-
+;iceTcp=1

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -125,12 +125,15 @@
 ;externalAddress=198.51.100.1
 ;externalAddress=2001:0db8:85a3:0000:0000:8a2e:0370:7334
 
-;; Whether to enable TCP candidate gathering via NiceAgent's ice-tcp property.
-;; The motivation behind this is to potentially speed up gathering
-;; by preventing TCP candidate gathering in scenarios where they aren't needed.
-;; Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
+;; Enable ICE-TCP candidate gathering.
 ;;
-;; <niceAgentIceTcp> MUST be either 0 (FALSE) or 1 (TRUE)
-;; Default is 1 (TRUE)
+;; This setting enables or disables using TCP for ICE candidate gathering in
+;; the underlying libnice library:
+;; https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
+;;
+;; You might want to disable ICE-TCP to potentially speed up ICE gathering
+;; by avoiding TCP candidates in scenarios where they are not needed.
+;;
+;; <iceTcp> is either 1 (ON) or 0 (OFF). Default: 1 (ON).
 ;;
 ;iceTcp=1

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -54,9 +54,11 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
 #define PARAM_EXTERNAL_ADDRESS "externalAddress"
 #define PARAM_NETWORK_INTERFACES "networkInterfaces"
+#define PARAM_NICEAGENT_ICE_TCP "niceAgentIceTcp"
 
 #define PROP_EXTERNAL_ADDRESS "external-address"
 #define PROP_NETWORK_INTERFACES "network-interfaces"
+#define PROP_NICEAGENT_ICE_TCP "niceagent-ice-tcp"
 
 namespace kurento
 {
@@ -532,6 +534,17 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
                " you can set one or default to ICE automatic discovery");
   }
 
+  gboolean niceAgentIceTcp;
+  if (getConfigValue <gboolean, WebRtcEndpoint> (&niceAgentIceTcp,
+      PARAM_NICEAGENT_ICE_TCP)) {
+    GST_INFO ("NiceAgent ice-tcp set to %d", niceAgentIceTcp);
+    g_object_set (G_OBJECT (element), PROP_NICEAGENT_ICE_TCP,
+        niceAgentIceTcp, NULL);
+  } else {
+    GST_DEBUG ("NiceAgent ice-tcp option not found in config;"
+               " you can set one or default to ice-tcp 1 - TRUE");
+  }
+
   uint stunPort = 0;
 
   if (!getConfigValue <uint, WebRtcEndpoint> (&stunPort, "stunServerPort",
@@ -670,6 +683,23 @@ WebRtcEndpointImpl::setNetworkInterfaces (const std::string &networkInterfaces)
   GST_INFO ("Set network interfaces: %s", networkInterfaces.c_str());
   g_object_set (G_OBJECT (element), PROP_NETWORK_INTERFACES,
       networkInterfaces.c_str(), NULL);
+}
+
+bool
+WebRtcEndpointImpl::getNiceAgentIceTcp ()
+{
+  bool ret;
+
+  g_object_get ( G_OBJECT (element), "niceagent-ice-tcp", &ret, NULL);
+
+  return ret;
+}
+
+void
+WebRtcEndpointImpl::setNiceAgentIceTcp (bool niceAgentIceTcp)
+{
+  g_object_set ( G_OBJECT (element), "niceagent-ice-tcp",
+                 niceAgentIceTcp, NULL);
 }
 
 std::string

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -56,13 +56,13 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define PARAM_EXTERNAL_IPV4 "externalIPv4"
 #define PARAM_EXTERNAL_IPV6 "externalIPv6"
 #define PARAM_NETWORK_INTERFACES "networkInterfaces"
-#define PARAM_NICEAGENT_ICE_TCP "niceAgentIceTcp"
+#define PARAM_ICE_TCP "iceTcp"
 
 #define PROP_EXTERNAL_ADDRESS "external-address"
 #define PROP_EXTERNAL_IPV4 "external-ipv4"
 #define PROP_EXTERNAL_IPV6 "external-ipv6"
 #define PROP_NETWORK_INTERFACES "network-interfaces"
-#define PROP_NICEAGENT_ICE_TCP "niceagent-ice-tcp"
+#define PROP_ICE_TCP "ice-tcp"
 
 namespace kurento
 {
@@ -560,15 +560,14 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
                " you can set one or default to ICE automatic discovery");
   }
 
-  gboolean niceAgentIceTcp;
-  if (getConfigValue <gboolean, WebRtcEndpoint> (&niceAgentIceTcp,
-      PARAM_NICEAGENT_ICE_TCP)) {
-    GST_INFO ("NiceAgent ice-tcp set to %d", niceAgentIceTcp);
-    g_object_set (G_OBJECT (element), PROP_NICEAGENT_ICE_TCP,
-        niceAgentIceTcp, NULL);
+  gboolean iceTcp;
+  if (getConfigValue<gboolean, WebRtcEndpoint> (&iceTcp, PARAM_ICE_TCP)) {
+    GST_INFO ("ICE-TCP candidate gathering is %s",
+        iceTcp ? "ENABLED" : "DISABLED");
+    g_object_set (G_OBJECT (element), PROP_ICE_TCP, iceTcp, NULL);
   } else {
-    GST_DEBUG ("NiceAgent ice-tcp option not found in config;"
-               " you can set one or default to ice-tcp 1 - TRUE");
+    GST_DEBUG ("ICE-TCP option not found in config;"
+               " you can set one or default to 1 (TRUE)");
   }
 
   uint stunPort = 0;
@@ -760,20 +759,19 @@ WebRtcEndpointImpl::setNetworkInterfaces (const std::string &networkInterfaces)
 }
 
 bool
-WebRtcEndpointImpl::getNiceAgentIceTcp ()
+WebRtcEndpointImpl::getIceTcp ()
 {
   bool ret;
 
-  g_object_get ( G_OBJECT (element), "niceagent-ice-tcp", &ret, NULL);
+  g_object_get (G_OBJECT (element), "ice-tcp", &ret, NULL);
 
   return ret;
 }
 
 void
-WebRtcEndpointImpl::setNiceAgentIceTcp (bool niceAgentIceTcp)
+WebRtcEndpointImpl::setIceTcp (bool iceTcp)
 {
-  g_object_set ( G_OBJECT (element), "niceagent-ice-tcp",
-                 niceAgentIceTcp, NULL);
+  g_object_set (G_OBJECT (element), "ice-tcp", iceTcp, NULL);
 }
 
 std::string

--- a/src/server/implementation/objects/WebRtcEndpointImpl.hpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.hpp
@@ -52,6 +52,9 @@ public:
   std::string getNetworkInterfaces () override;
   void setNetworkInterfaces (const std::string &networkInterfaces) override;
 
+  bool getNiceAgentIceTcp () override;
+  void setNiceAgentIceTcp (bool niceAgentIceTcp) override;
+
   std::string getStunServerAddress () override;
   void setStunServerAddress (const std::string &stunServerAddress) override;
 

--- a/src/server/implementation/objects/WebRtcEndpointImpl.hpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.hpp
@@ -58,8 +58,8 @@ public:
   std::string getNetworkInterfaces () override;
   void setNetworkInterfaces (const std::string &networkInterfaces) override;
 
-  bool getNiceAgentIceTcp () override;
-  void setNiceAgentIceTcp (bool niceAgentIceTcp) override;
+  bool getIceTcp () override;
+  void setIceTcp (bool iceTcp) override;
 
   std::string getStunServerAddress () override;
   void setStunServerAddress (const std::string &stunServerAddress) override;

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -305,6 +305,11 @@
           "type": "String"
         },
         {
+          "name": "niceAgentIceTcp",
+          "doc": "Enable libnice agent's ice-tcp option",
+          "type": "boolean"
+        },
+        {
           "name": "stunServerAddress",
           "doc": "STUN server IP address.
 <p>The ICE process uses STUN to punch holes through NAT firewalls.</p>

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -305,8 +305,19 @@
           "type": "String"
         },
         {
-          "doc": "Enable libnice agent's ice-tcp option",
           "name": "iceTcp",
+          "doc": "Enable ICE-TCP candidate gathering.
+<p>
+  This setting enables or disables using TCP for ICE candidate gathering in the
+  underlying libnice library:
+  https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
+</p>
+<p>
+  You might want to disable ICE-TCP to potentially speed up ICE gathering by
+  avoiding TCP candidates in scenarios where they are not needed.
+</p>
+<p><code>iceTcp</code> is either 1 (ON) or 0 (OFF). Default: 1 (ON).</p>
+          ",
           "type": "boolean"
         },
         {

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -305,8 +305,8 @@
           "type": "String"
         },
         {
-          "name": "niceAgentIceTcp",
           "doc": "Enable libnice agent's ice-tcp option",
+          "name": "iceTcp",
           "type": "boolean"
         },
         {


### PR DESCRIPTION
## What is the current behavior you want to change?

Currently, `ice-tcp` is not explicitly set in Kurento's NiceAgent usage; therefore, it defaults to `TRUE` (libnice's default) and always does TCP candidate gathering.

Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp

## What is the new behavior provided by this change?

The rationale behind this is to give the ability to deactivate TCP candidate gathering in setups where they aren`t needed, thus potentially speeding up the gathering process/connectivity checks and trimming down the number of generated candidates/bound sockets.

From the WebRtcEndpoint.conf.ini:
```
;; Whether to enable TCP candidate gathering via NiceAgent's ice-tcp property.
;; The motivation behind this is to potentially speed up gathering
;; by preventing TCP candidate gathering in scenarios where they aren't needed.
;; Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
;;
;; <niceAgentIceTcp> MUST be either 0 (FALSE) or 1 (TRUE)
;; Default is 1 (TRUE)
;niceAgentIceTcp=1
```

A pair of API methods was also added to be able to control this per element:
  - `WebRtcEndpoint.setNiceAgentIceTcp(true|false)`
  - `WebRtcEndpoint.getNiceAgentIceTcp`

## How has this been tested?
- Compiled on 16.04
- Manually tested:
  * WebRtcEndpoint.conf.ini#niceAgentIceTcp: 1|0, by observing about:webrtc and chrome:webrtc-internals dumps to verify the generated server-side candidates
  * WebRtcEndpoint#setNiceAgentIceTcp(true|false), *via the JS client*, by observing about:webrtc and chrome:webrtc-internals dumps to verify the generated server-side candidates
- **Pending**: unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
