### PR TITLE
Add externalIPv4/externalIPv6 configs and API methods for them

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
@@ -56,6 +56,8 @@ G_DEFINE_TYPE (KmsWebrtcEndpoint, kms_webrtc_endpoint,
 #define DEFAULT_PEM_CERTIFICATE NULL
 #define DEFAULT_NETWORK_INTERFACES NULL
 #define DEFAULT_EXTERNAL_ADDRESS NULL
+#define DEFAULT_EXTERNAL_IPV4 NULL
+#define DEFAULT_EXTERNAL_IPV6 NULL
 
 enum
 {
@@ -66,6 +68,8 @@ enum
   PROP_PEM_CERTIFICATE,
   PROP_NETWORK_INTERFACES,
   PROP_EXTERNAL_ADDRESS,
+  PROP_EXTERNAL_IPV4,
+  PROP_EXTERNAL_IPV6,
   N_PROPERTIES
 };
 
@@ -99,6 +103,8 @@ struct _KmsWebrtcEndpointPrivate
   gchar *pem_certificate;
   gchar *network_interfaces;
   gchar *external_address;
+  gchar *external_ipv4;
+  gchar *external_ipv6;
 };
 
 /* Internal session management begin */
@@ -329,13 +335,19 @@ kms_webrtc_endpoint_create_session_internal (KmsBaseSdpEndpoint * base_sdp,
       webrtc_sess, "network-interfaces", G_BINDING_DEFAULT);
   g_object_bind_property (self, "external-address",
       webrtc_sess, "external-address", G_BINDING_DEFAULT);
+  g_object_bind_property (self, "external-ipv4",
+      webrtc_sess, "external-ipv4", G_BINDING_DEFAULT);
+  g_object_bind_property (self, "external-ipv6",
+      webrtc_sess, "external-ipv6", G_BINDING_DEFAULT);
 
   g_object_set (webrtc_sess, "stun-server", self->priv->stun_server_ip,
       "stun-server-port", self->priv->stun_server_port,
       "turn-url", self->priv->turn_url,
       "pem-certificate", self->priv->pem_certificate,
       "network-interfaces", self->priv->network_interfaces,
-      "external-address", self->priv->external_address, NULL);
+      "external-address", self->priv->external_address,
+      "external-ipv4", self->priv->external_ipv4,
+      "external-ipv6", self->priv->external_ipv6, NULL);
 
   g_signal_connect (webrtc_sess, "on-ice-candidate",
       G_CALLBACK (on_ice_candidate), self);
@@ -511,6 +523,14 @@ kms_webrtc_endpoint_set_property (GObject * object, guint prop_id,
       g_free (self->priv->external_address);
       self->priv->external_address = g_value_dup_string (value);
       break;
+    case PROP_EXTERNAL_IPV4:
+      g_free (self->priv->external_ipv4);
+      self->priv->external_ipv4 = g_value_dup_string (value);
+      break;
+    case PROP_EXTERNAL_IPV6:
+      g_free (self->priv->external_ipv6);
+      self->priv->external_ipv6 = g_value_dup_string (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -545,6 +565,12 @@ kms_webrtc_endpoint_get_property (GObject * object, guint prop_id,
       break;
     case PROP_EXTERNAL_ADDRESS:
       g_value_set_string (value, self->priv->external_address);
+      break;
+    case PROP_EXTERNAL_IPV4:
+      g_value_set_string (value, self->priv->external_ipv4);
+      break;
+    case PROP_EXTERNAL_IPV6:
+      g_value_set_string (value, self->priv->external_ipv6);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -583,6 +609,8 @@ kms_webrtc_endpoint_finalize (GObject * object)
   g_free (self->priv->pem_certificate);
   g_free (self->priv->network_interfaces);
   g_free (self->priv->external_address);
+  g_free (self->priv->external_ipv4);
+  g_free (self->priv->external_ipv6);
 
   g_main_context_unref (self->priv->context);
 
@@ -771,6 +799,18 @@ kms_webrtc_endpoint_class_init (KmsWebrtcEndpointClass * klass)
           "External (public) IP address of the media server",
           DEFAULT_EXTERNAL_ADDRESS, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_EXTERNAL_IPV4,
+      g_param_spec_string ("external-ipv4",
+          "externalIPv4",
+          "External (public) IPv4 address of the media server",
+          DEFAULT_EXTERNAL_IPV4, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_EXTERNAL_IPV6,
+      g_param_spec_string ("external-ipv6",
+          "externalIPv6",
+          "External (public) IPv6 address of the media server",
+          DEFAULT_EXTERNAL_IPV6, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   /**
   * KmsWebrtcEndpoint::on-ice-candidate:
   * @self: the object which received the signal
@@ -905,6 +945,8 @@ kms_webrtc_endpoint_init (KmsWebrtcEndpoint * self)
   self->priv->pem_certificate = DEFAULT_PEM_CERTIFICATE;
   self->priv->network_interfaces = DEFAULT_NETWORK_INTERFACES;
   self->priv->external_address = DEFAULT_EXTERNAL_ADDRESS;
+  self->priv->external_ipv4 = DEFAULT_EXTERNAL_IPV4;
+  self->priv->external_ipv6 = DEFAULT_EXTERNAL_IPV6;
 
   self->priv->loop = kms_loop_new ();
   g_object_get (self->priv->loop, "context", &self->priv->context, NULL);

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
@@ -72,6 +72,8 @@ struct _KmsWebrtcSession
   gchar *pem_certificate;
   gchar *network_interfaces;
   gchar *external_address;
+  gchar *external_ipv4;
+  gchar *external_ipv6;
 
   guint16 min_port;
   guint16 max_port;

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -102,3 +102,31 @@
 ;; externalAddress=2001:0db8:85a3:0000:0000:8a2e:0370:7334
 ;;
 ;externalAddress=10.20.30.40
+
+;; External IPv4 address of the media server.
+;;
+;; This setting follows the same rationale of the externalAddress setting, but
+;; the idea here is to couple it with the externalIPv6 setting to achieve dual
+;; stack IPv4+IPv6 candidate mangling.
+;;
+;; Right now, externalAddress only allows a single IP (which has to be either
+;; IPv4 or IPv6), so it's not dual stack friendly. This option will mangle
+;; IPv4 candidates with the specified one.
+;;
+;; For the sake of backwards compatibility, externalAddress has preference over
+;; this: when externalAddress is set, this option will be ignored.
+;;
+;; <externalIPv4> is an IPv4 address.
+;;
+; externalIPv4=10.20.30.40
+
+;; External IPv6 address of the media server.
+;;
+;; Refer to the detailing of externalIPv4 which should explain this as well.
+;;
+;; For the sake of backwards compatibility, externalAddress has preference over
+;; this: when externalAddress is set, this option will be ignored.
+;;
+;; <externalIPv6> is an IPv6 address.
+;;
+; externalIPv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -53,9 +53,13 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define DEFAULT_PATH "/etc/kurento"
 
 #define PARAM_EXTERNAL_ADDRESS "externalAddress"
+#define PARAM_EXTERNAL_IPV4 "externalIPv4"
+#define PARAM_EXTERNAL_IPV6 "externalIPv6"
 #define PARAM_NETWORK_INTERFACES "networkInterfaces"
 
 #define PROP_EXTERNAL_ADDRESS "external-address"
+#define PROP_EXTERNAL_IPV4 "external-ipv4"
+#define PROP_EXTERNAL_IPV6 "external-ipv6"
 #define PROP_NETWORK_INTERFACES "network-interfaces"
 
 namespace kurento
@@ -510,6 +514,28 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
 
   //set properties
 
+  std::string externalIPv4;
+  if (getConfigValue <std::string, WebRtcEndpoint> (&externalIPv4,
+      PARAM_EXTERNAL_IPV4)) {
+    GST_INFO ("Predefined external IPv4 address: %s", externalIPv4.c_str());
+    g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV4,
+        externalIPv4.c_str(), NULL);
+  } else {
+    GST_DEBUG ("No predefined external IPv4 address found in config;"
+               " you can set one or default to STUN automatic discovery");
+  }
+
+  std::string externalIPv6;
+  if (getConfigValue <std::string, WebRtcEndpoint> (&externalIPv6,
+      PARAM_EXTERNAL_IPV6)) {
+    GST_INFO ("Predefined external IPv6 address: %s", externalIPv6.c_str());
+    g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV6,
+        externalIPv6.c_str(), NULL);
+  } else {
+    GST_DEBUG ("No predefined external IPv6 address found in config;"
+               " you can set one or default to STUN automatic discovery");
+  }
+
   std::string externalAddress;
   if (getConfigValue <std::string, WebRtcEndpoint> (&externalAddress,
       PARAM_EXTERNAL_ADDRESS)) {
@@ -622,6 +648,54 @@ WebRtcEndpointImpl::~WebRtcEndpointImpl()
   if (handlerNewSelectedPairFull > 0) {
     unregister_signal_handler (element, handlerNewSelectedPairFull);
   }
+}
+
+std::string
+WebRtcEndpointImpl::getExternalIPv4 ()
+{
+  std::string externalIPv4;
+  gchar *ret;
+
+  g_object_get (G_OBJECT (element), PROP_EXTERNAL_IPV4, &ret, NULL);
+
+  if (ret != nullptr) {
+    externalIPv4 = std::string (ret);
+    g_free (ret);
+  }
+
+  return externalIPv4;
+}
+
+void
+WebRtcEndpointImpl::setExternalIPv4 (const std::string &externalIPv4)
+{
+  GST_INFO ("Set external IPv4 address: %s", externalIPv4.c_str());
+  g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV4,
+      externalIPv4.c_str(), NULL);
+}
+
+std::string
+WebRtcEndpointImpl::getExternalIPv6 ()
+{
+  std::string externalIPv6;
+  gchar *ret;
+
+  g_object_get (G_OBJECT (element), PROP_EXTERNAL_IPV6, &ret, NULL);
+
+  if (ret != nullptr) {
+    externalIPv6 = std::string (ret);
+    g_free (ret);
+  }
+
+  return externalIPv6;
+}
+
+void
+WebRtcEndpointImpl::setExternalIPv6 (const std::string &externalIPv6)
+{
+  GST_INFO ("Set external IPv6 address: %s", externalIPv6.c_str());
+  g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV6,
+      externalIPv6.c_str(), NULL);
 }
 
 std::string

--- a/src/server/implementation/objects/WebRtcEndpointImpl.hpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.hpp
@@ -46,6 +46,12 @@ public:
 
   ~WebRtcEndpointImpl () override;
 
+  std::string getExternalIPv6 () override;
+  void setExternalIPv6 (const std::string &externalIPv6) override;
+
+  std::string getExternalIPv4() override;
+  void setExternalIPv4 (const std::string &externalIPv4) override;
+
   std::string getExternalAddress () override;
   void setExternalAddress (const std::string &externalAddress) override;
 

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -358,6 +358,16 @@
           "type": "String"
         },
         {
+          "name": "externalIPv4",
+          "doc": "External IPv4 of the media server",
+          "type": "String"
+        },
+        {
+          "name": "externalIPv6",
+          "doc": "External IPv6 of the media server",
+          "type": "String"
+        },
+        {
           "name": "externalAddress",
           "doc": "External IP address of the media server.
 <p>


### PR DESCRIPTION
## What is the current behavior you want to change?

Currently, `externalAddress` allows only for a single IP that will be either IPv4 or IPv6. That's not friendly with dual stack IPv4+IPv6 environments.

Related issue: https://github.com/Kurento/bugtracker/issues/522

## What is the new behavior provided by this change?

This pull request splits the `externalAddress` config into two new ones
  - `externalIPv4`
  - `externalIPv6`

They can be used concurrently and will mangle compatible IPv_X candidates.

`externalAddress` will still have precedence of these two new options: if it's set, `externalIPv4/externalIPv6` will be ignored

From the `WebRtcEndpoint.conf.ini` explanation:

```
;; External IPv4 address of the media server.
;;
;; This setting follows the same rationale of the externalAddress setting, but
;; the idea here is to couple it with the externalIPv6 setting to achieve dual
;; stack IPv4+IPv6 candidate mangling.
;;
;; Right now, externalAddress only allows a single IP (which has to be either
;; IPv4 or IPv6), so it's not dual stack friendly. This option will mangle
;; IPv4 candidates with the specified one.
;;
;; For the sake of backwards compatibility, externalAddress has preference over
;; this: when externalAddress is set, this option will be ignored.
;;
;; <externalIPv4> is an IPv4 address.
;;
; externalIPv4=10.20.30.40

;; External IPv6 address of the media server.
;;
;; Refer to the detailing of externalIPv4 which should explain this as well.
;;
;; For the sake of backwards compatibility, externalAddress has preference over
;; this: when externalAddress is set, this option will be ignored.
;;
;; <externalIPv6> is an IPv6 address.
;;
; externalIPv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334
```

## How has this been tested?

  - Compiled on 16.04
  - Manually tested:
    * WebRtcEndpoint.conf.ini#externalIPv4/IPv6: IPv4|IPv6, by observing about:webrtc and chrome:webrtc-internals dumps to verify the generated server-side candidates and see if they match the configured values. Also bumped KMS's logs to see if they right, compatible candidates were being mangled.
    * WebRtcEndpoint#setExternalIPv4/IPv6(IPv4|IPv6), _via the JS client_,  to verify the generated server-side candidates and see if they match the configured values. Also bumped KMS's logs to see if they right, compatible candidates were being mangled.
    * Pending: **unit tests**

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist

- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
