### PR TITLE
CMakeLists.txt: explicitly list the Boost libraries required for linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set(NICE_REQUIRED ^0.1.13)
 set(GLIBMM_REQUIRED ^2.37)
 
 include(GenericFind)
-generic_find(LIBNAME Boost REQUIRED COMPONENTS unit_test_framework)
+generic_find(LIBNAME Boost REQUIRED COMPONENTS unit_test_framework system filesystem thread)
 generic_find(LIBNAME gstreamer-1.5 VERSION ${GST_REQUIRED} REQUIRED)
 generic_find(LIBNAME gstreamer-base-1.5 VERSION ${GST_REQUIRED} REQUIRED)
 generic_find(LIBNAME gstreamer-video-1.5 VERSION ${GST_REQUIRED} REQUIRED)


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
On more recent systems (e.g. CMake 3.18, gcc 10, Debian 11), the build fails if these Boost libraries are not listed


## What is the new behavior provided by this change?
Ensures that the build is successful


## How has this been tested?
Building on a Debian 11 system (CMake 3.18, gcc 10)


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
