### PR TITLE
Revert "DTLS server quick connection fix (#38)"

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbundleconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbundleconnection.c
@@ -93,7 +93,6 @@ kms_webrtc_bundle_connection_add (KmsIRtpConnection * base_rtp_conn,
   KmsWebRtcTransport *tr = priv->tr;
 
   kms_webrtc_transport_sink_set_dtls_is_client (tr->sink, active);
-  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcconnection.c
@@ -80,7 +80,6 @@ static void
 add_tr (KmsWebRtcTransport * tr, GstBin * bin, gboolean is_client)
 {
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, is_client);
-  kms_webrtc_transport_src_set_dtls_is_client (tr->src, is_client);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcrtcpmuxconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcrtcpmuxconnection.c
@@ -88,7 +88,6 @@ kms_webrtc_rtcp_mux_connection_add (KmsIRtpConnection * base_rtp_conn,
 
   /* srcs */
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, active);
-  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsctpconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsctpconnection.c
@@ -80,7 +80,6 @@ kms_webrtc_sctp_connection_add (KmsIRtpConnection * base_conn, GstBin * bin,
   KmsWebRtcTransport *tr = priv->tr;
 
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, active);
-  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (self->priv->tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (self->priv->tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
@@ -29,85 +29,7 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define kms_webrtc_transport_src_parent_class parent_class
 G_DEFINE_TYPE (KmsWebrtcTransportSrc, kms_webrtc_transport_src, GST_TYPE_BIN);
 
-#define SRTPDEC_FACTORY_NAME "srtpdec"
-
-
-// {{{{ FIXME: This can be deleted when we start using GStreamer >=1.18 for Kurento.
-// Code sourced from GStreamer/gstbin.c >=1.18
-//
-// https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4526-4537
-static gint
-compare_factory_names (const GValue *velement, GValue *factory_name_val)
-{
-  GstElement *element = g_value_get_object (velement);
-  GstElementFactory *factory = gst_element_get_factory (element);
-  const gchar *factory_name = g_value_get_string (factory_name_val);
-
-  if (factory == NULL)
-    return -1;
-
-  return g_strcmp0 (GST_OBJECT_NAME (factory), factory_name);
-}
-
-//
-// https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4553-4574
-GstIterator *
-gst_bin_iterate_all_by_element_factory_name (GstBin *bin,
-    const gchar *factory_name)
-{
-  GstIterator *children;
-  GstIterator *result;
-  GValue factory_name_val = G_VALUE_INIT;
-
-  g_return_val_if_fail (GST_IS_BIN (bin), NULL);
-  g_return_val_if_fail (factory_name && *factory_name, NULL);
-
-  g_value_init (&factory_name_val, G_TYPE_STRING);
-  g_value_set_string (&factory_name_val, factory_name);
-
-  children = gst_bin_iterate_recurse (bin);
-  result = gst_iterator_filter (children, (GCompareFunc)compare_factory_names,
-      &factory_name_val);
-
-  g_value_unset (&factory_name_val);
-
-  return result;
-}
-// }}}}
-
-static GstElement *
-kms_webrtc_transport_src_get_element_in_dtlssrtpdec (
-    KmsWebrtcTransportSrc *self,
-    const gchar *factory_name)
-{
-  GstElement *element = NULL;
-  GValue velement = G_VALUE_INIT;
-
-  GstIterator *iter = gst_bin_iterate_all_by_element_factory_name (
-      GST_BIN (self->dtlssrtpdec), factory_name);
-
-  if (gst_iterator_next (iter, &velement) == GST_ITERATOR_OK) {
-    // Assume only one element of the given type. This is the case in dtlssrtpdec.
-    element = g_value_dup_object (&velement);
-    g_value_reset (&velement);
-  }
-
-  if (gst_iterator_next (iter, &velement) != GST_ITERATOR_DONE) {
-    GST_WARNING_OBJECT (self,
-        "BUG: Several elements '%s' found in dtlssrtpdec; code assumes only one",
-        factory_name);
-  }
-
-  if (element == NULL) {
-    GST_WARNING_OBJECT (self, "BUG: Element '%s' not found in dtlssrtpdec",
-        factory_name);
-  }
-
-  g_value_unset (&velement);
-  gst_iterator_free (iter);
-
-  return element;
-}  
+#define SRTPDEC_NAME "srtp-decoder"
 
 static void
 kms_webrtc_transport_src_init (KmsWebrtcTransportSrc * self)
@@ -123,12 +45,12 @@ kms_webrtc_transport_src_connect_elements (KmsWebrtcTransportSrc * self)
   gst_bin_add_many (GST_BIN (self), self->src, self->dtlssrtpdec, NULL);
   gst_element_link (self->src, self->dtlssrtpdec);
 
-  srtpdec = kms_webrtc_transport_src_get_element_in_dtlssrtpdec (self, SRTPDEC_FACTORY_NAME);
+  srtpdec = gst_bin_get_by_name (GST_BIN (self->dtlssrtpdec), SRTPDEC_NAME);
   if (srtpdec != NULL) {
     g_object_set (srtpdec, "replay-window-size", RTP_RTX_SIZE, NULL);
     g_object_unref (srtpdec);
   } else {
-    GST_WARNING ("Cannot get SRTP DTLS decoder");
+    GST_WARNING ("Cannot get srtpdec with name %s", SRTPDEC_NAME);
   }
 }
 
@@ -155,27 +77,12 @@ kms_webrtc_transport_src_configure (KmsWebrtcTransportSrc * self,
   klass->configure (self, agent, stream_id, component_id);
 }
 
-void
-kms_webrtc_transport_src_set_dtls_is_client_default (KmsWebrtcTransportSrc * self,
-    gboolean is_client)
-{
-  // We just need to cache the DTLS client value for later use
-  self->dtls_client = is_client;  
-
-  if (is_client) {
-    GST_DEBUG_OBJECT(self, "Set as DTLS client (handshake initiator)");
-  } else {
-    GST_DEBUG_OBJECT(self, "Set as DTLS server (wait for handshake)");
-  }
-}
-
 static void
 kms_webrtc_transport_src_class_init (KmsWebrtcTransportSrcClass * klass)
 {
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
 
   klass->configure = kms_webrtc_transport_src_configure_default;
-  klass->set_dtls_is_client = kms_webrtc_transport_src_set_dtls_is_client_default;
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_DEFAULT_NAME, 0,
       GST_DEFAULT_NAME);
@@ -195,14 +102,4 @@ kms_webrtc_transport_src_new ()
   obj = g_object_new (KMS_TYPE_WEBRTC_TRANSPORT_SRC, NULL);
 
   return KMS_WEBRTC_TRANSPORT_SRC (obj);
-}
-
-void
-kms_webrtc_transport_src_set_dtls_is_client (KmsWebrtcTransportSrc * self,
-    gboolean is_client)
-{
-  KmsWebrtcTransportSrcClass *klass =
-      KMS_WEBRTC_TRANSPORT_SRC_CLASS (G_OBJECT_GET_CLASS (self));
-
-  klass->set_dtls_is_client (self, is_client);
 }

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.h
@@ -45,8 +45,6 @@ struct _KmsWebrtcTransportSrc
   GstElement *src;
   GstElement *dtlssrtpdec;
   gulong src_probe;
-
-  gboolean dtls_client;
 };
 
 struct _KmsWebrtcTransportSrcClass
@@ -58,10 +56,6 @@ struct _KmsWebrtcTransportSrcClass
                          KmsIceBaseAgent *agent,
                          const char *stream_id,
                          guint component_id);
-
-  void (*set_dtls_is_client) (KmsWebrtcTransportSrc * self,
-                          gboolean is_client);
-
 };
 
 GType kms_webrtc_transport_src_get_type (void);
@@ -72,9 +66,6 @@ void kms_webrtc_transport_src_configure (KmsWebrtcTransportSrc * self,
                                              KmsIceBaseAgent *agent,
                                              const char *stream_id,
                                              guint component_id);
-
-void kms_webrtc_transport_src_set_dtls_is_client (KmsWebrtcTransportSrc *src, 
-                                                  gboolean is_client);
 
 G_END_DECLS
 #endif /* __KMS_WEBRTC_TRANSPORT_SRC_H__ */

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
@@ -29,172 +29,17 @@
 GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
 #define kms_webrtc_transport_src__nice_parent_class parent_class
-
-#define KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK(src_nice) \
-  (g_rec_mutex_lock (&(src_nice)->priv->mutex))
-
-#define KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK(src_nice) \
-  (g_rec_mutex_unlock (&(src_nice)->priv->mutex))
-
-#define KMS_WEBRTC_TRANSPORT_SRC_NICE_GET_PRIVATE(obj) ( \
-  G_TYPE_INSTANCE_GET_PRIVATE (                       \
-    (obj),                                            \
-    KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,                  \
-    KmsWebrtcTransportSrcNicePrivate                    \
-  )                                                   \
-)
-
-// First byte of a DTLS packet is in the range 19 < B < 64.
-// Doc: https://datatracker.ietf.org/doc/html/rfc5764#section-5.1.2
-#define PACKET_IS_DTLS(b) ((b) > 0x13 && (b) < 0x40)
-
-struct _KmsWebrtcTransportSrcNicePrivate
-{
-  GRecMutex mutex;
-
-  gboolean pending_buffers_delivered;
-
-  GList *pending_buffers;
-};
-
-G_DEFINE_TYPE_WITH_CODE (KmsWebrtcTransportSrcNice, kms_webrtc_transport_src_nice, KMS_TYPE_WEBRTC_TRANSPORT_SRC,
-    G_ADD_PRIVATE (KmsWebrtcTransportSrcNice));
-
-
-
-static gboolean
-gst_buffer_is_dtls (GstBuffer *buffer)
-{
-  guint8 first_byte;
-
-  if (gst_buffer_get_size (buffer) == 0) {
-    GST_DEBUG ("Ignoring buffer with size 0");
-    return FALSE;
-  }
-
-  if (gst_buffer_extract (buffer, 0, &first_byte, 1) != 1) {
-    GST_WARNING ("Could not extract first byte from buffer");
-    return FALSE;
-  }
-
-  return PACKET_IS_DTLS (first_byte);
-}
-
-// Stores DTLS buffers for later use.
-// `buffer` is unref and set to NULL only if stored; otherwise left as-is.
-static gboolean
-store_pending_dtls_buffer (GstBuffer **buffer, guint idx, gpointer user_data)
-{
-  if (gst_buffer_is_dtls (*buffer)) {
-    KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (user_data);
-
-    GST_DEBUG_OBJECT (self, "Storing DTLS buffer until ICE is CONNECTED");
-    self->priv->pending_buffers = g_list_append (self->priv->pending_buffers, *buffer);
-
-    // Side effect: Remove the buffer from its buffer list, if any.
-    *buffer = NULL;
-  }
-
-  return TRUE;
-}
-
-
+G_DEFINE_TYPE (KmsWebrtcTransportSrcNice, kms_webrtc_transport_src_nice,
+    KMS_TYPE_WEBRTC_TRANSPORT_SRC);
 
 static void
 kms_webrtc_transport_src_nice_init (KmsWebrtcTransportSrcNice * self)
 {
   KmsWebrtcTransportSrc *parent = KMS_WEBRTC_TRANSPORT_SRC (self);
 
-  self->priv = KMS_WEBRTC_TRANSPORT_SRC_NICE_GET_PRIVATE (self);
   parent->src = gst_element_factory_make ("nicesrc", NULL);
 
   kms_webrtc_transport_src_connect_elements (parent);
-}
-
-static void
-kms_webrtc_transport_src_nice_finalize (GObject * object)
-{
-  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (object);
-
-  if (self->priv->pending_buffers != NULL) {
-    g_list_free_full (self->priv->pending_buffers, (GDestroyNotify)gst_buffer_unref);
-    self->priv->pending_buffers = NULL;
-  }
-}
-
-static void
-kms_webrtc_transport_src_nice_send_pending_buffer (GstBuffer *buffer, KmsWebrtcTransportSrc *self)
-{
-  GstPad *nicesrc_src = gst_element_get_static_pad (self->src, "src");
-
-  if (gst_pad_push (nicesrc_src, buffer) == GST_FLOW_ERROR ) {
-    GST_INFO_OBJECT (self, "Cannot deliver delayed buffer");
-  } else {
-    GST_DEBUG_OBJECT (self, "Delivered delayed buffer");
-  }
-  gst_object_unref (nicesrc_src);
-}
-
-
-static gboolean 
-do_send_pending_buffers (GstClock * clock,
-                     GstClockTime time,
-                     GstClockID id,
-                     gpointer user_data)
-{
-  GList *pending_buffers;
-  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (user_data);
-
-  KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
-  pending_buffers = self->priv->pending_buffers;
-  self->priv->pending_buffers = NULL;
-  KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
-
-  if (pending_buffers != NULL) {
-    g_list_foreach (pending_buffers, (GFunc) kms_webrtc_transport_src_nice_send_pending_buffer, self);
-    g_list_free (pending_buffers);
-  }
-  return TRUE;
-}
-
-static void
-kms_webrtc_transport_src_nice_component_state_changed (KmsIceBaseAgent * agent,
-    char *stream_id, guint component_id, IceState state,
-    KmsWebrtcTransportSrcNice * self)
-{
-  gboolean is_client;
-  KmsWebrtcTransportSrc *parent = KMS_WEBRTC_TRANSPORT_SRC(self);
-
-  GST_LOG_OBJECT (self,
-      "[IceComponentStateChanged] state: %s, stream_id: %s, component_id: %u",
-      kms_ice_base_agent_state_to_string (state), stream_id, component_id);
-
-  is_client = parent->dtls_client;
-
-  if (state == ICE_STATE_CONNECTED) {
-    if (!is_client) {
-      // Send all pending buffer, if any and signal probe to be removed on next Buffer
-      KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
-      self->priv->pending_buffers_delivered = TRUE;
-      KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
-
-      // we have observed that if we immediately send the delayed buffer, and the openssl negotiation process starts, the server hello gets the nicesink not ready yet
-      // to send, so to avoid that we delayed the sending by 10 ms
-      if (self->priv->pending_buffers != NULL) {
-        GstClockTime now;
-        GstClockTime filter_time;
-        GstClockID filter_time_id;
-        GstClock *clock;
-
-        clock = gst_element_get_clock (parent->src);
-        now = gst_clock_get_time (clock);
-        filter_time = now + (GST_SECOND / 100);
-        filter_time_id = gst_clock_new_single_shot_id (clock, filter_time);
-        gst_clock_id_wait_async (filter_time_id, do_send_pending_buffers, gst_object_ref (self), gst_object_unref);
-        gst_object_unref (clock);
-      }
-    }
-  }
 }
 
 void
@@ -207,92 +52,17 @@ kms_webrtc_transport_src_nice_configure (KmsWebrtcTransportSrc * self,
   g_object_set (G_OBJECT (self->src),
       "agent", kms_ice_nice_agent_get_agent (nice_agent),
       "stream", id, "component", component_id, NULL);
-
-  g_signal_connect (nice_agent, "on-ice-component-state-changed",
-    G_CALLBACK (kms_webrtc_transport_src_nice_component_state_changed), self);
-}
-
-// Store DTLS buffers for later delivery when ICE gets to CONNECTED.
-static GstPadProbeReturn
-kms_webrtc_transport_src_nice_block_dtls_until_ice_connected (GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
-{
-  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE(user_data);
-  GstPadProbeReturn ret = GST_PAD_PROBE_OK;
-
-  KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
-  if (self->priv->pending_buffers_delivered) {
-    KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
-    GST_DEBUG_OBJECT (self, "No more possible buffers pending, removing probe");
-    return GST_PAD_PROBE_REMOVE;
-  }
-
-  if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
-    GstBuffer *buffer = gst_pad_probe_info_get_buffer (info);
-
-    if (buffer != NULL) {
-      store_pending_dtls_buffer (&buffer, 0, self);
-
-      if (buffer == NULL) {
-        ret = GST_PAD_PROBE_HANDLED;
-      }
-    }
-  }
-
-  if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER_LIST) {
-    GstBufferList *buffer_list = gst_pad_probe_info_get_buffer_list (info);
-
-    if (buffer_list != NULL) {
-      gst_buffer_list_foreach (buffer_list, store_pending_dtls_buffer, self);
-
-      if (gst_buffer_list_length (buffer_list) == 0) {
-        ret = GST_PAD_PROBE_HANDLED;
-      }
-    }
-  }
-  KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
-
-  return ret;
-}
-
-
-
-static void
-kms_webrtc_transport_src_nice_set_dtls_is_client (KmsWebrtcTransportSrc * src,
-    gboolean is_client)
-{
-  KmsWebrtcTransportSrcNiceClass *klass = 
-      KMS_WEBRTC_TRANSPORT_SRC_NICE_CLASS (G_OBJECT_GET_CLASS (src));
-  KmsWebrtcTransportSrcClass *parent_klass =
-      KMS_WEBRTC_TRANSPORT_SRC_CLASS  (g_type_class_peek_parent(klass));
-
-  parent_klass->set_dtls_is_client (src, is_client);
-
-  if (!is_client) {
-    // If is DTLS server (!is_client)
-    //    install a blocking probe in dtlssrtpdec sink pad
-    //    Blocking probe should buffer all GstBuffers sent to sink pad in dtlssrtpdec
-    //    Then when ICE gets to CONNECTED state it should resend all pending buffers
-    GstPad *nicesrc_src = gst_element_get_static_pad (src->src, "src");
-
-    gst_pad_add_probe (nicesrc_src, GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_BUFFER_LIST,  
-                      kms_webrtc_transport_src_nice_block_dtls_until_ice_connected, src, NULL);
-    gst_object_unref (nicesrc_src);
-  }
- 
 }
 
 static void
 kms_webrtc_transport_src_nice_class_init (KmsWebrtcTransportSrcNiceClass *
     klass)
 {
-  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
   KmsWebrtcTransportSrcClass *base_class;
 
-  gobject_class->finalize = kms_webrtc_transport_src_nice_finalize;
   base_class = KMS_WEBRTC_TRANSPORT_SRC_CLASS (klass);
   base_class->configure = kms_webrtc_transport_src_nice_configure;
-  base_class->set_dtls_is_client = kms_webrtc_transport_src_nice_set_dtls_is_client;
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_DEFAULT_NAME, 0,
       GST_DEFAULT_NAME);

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.h
@@ -28,7 +28,7 @@ G_BEGIN_DECLS
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST((obj),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,KmsWebrtcTransportSrcNice))
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST((klass),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,KmsWebrtcTransportSrcNiceClass))
+  (G_TYPE_CHECK_CLASS_CAST((klass),KMS_TYPE_WEBRTC_TRANSPORT_SRCNICE,KmsWebrtcTransportSrcNiceClass))
 #define KMS_IS_WEBRTC_TRANSPORT_SRC_NICE(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE))
 #define KMS_IS_WEBRTC_TRANSPORT_SRC_NICE_CLASS(klass) \
@@ -36,14 +36,11 @@ G_BEGIN_DECLS
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE_CAST(obj) ((KmsWebrtcTransportSrcNice*)(obj))
 
 typedef struct _KmsWebrtcTransportSrcNice KmsWebrtcTransportSrcNice;
-typedef struct _KmsWebrtcTransportSrcNicePrivate KmsWebrtcTransportSrcNicePrivate;
 typedef struct _KmsWebrtcTransportSrcNiceClass KmsWebrtcTransportSrcNiceClass;
 
 struct _KmsWebrtcTransportSrcNice
 {
   KmsWebrtcTransportSrc parent;
-
-  KmsWebrtcTransportSrcNicePrivate *priv;
 };
 
 struct _KmsWebrtcTransportSrcNiceClass

--- a/tests/server/webRtcEndpoint.cpp
+++ b/tests/server/webRtcEndpoint.cpp
@@ -249,7 +249,7 @@ ice_state_changes_ipv6 ()
 // That feature will be PR'd when KMS reaches at least GStreamer 1.17
 /******************************************************
 static  void
-dtls_quick_connection_dtls_client_test (bool useIpv6)
+dtls_quick_connection_test (bool useIpv6)
 {
   DtlsConnectionState offerer_dtls_connection_state = DtlsConnectionState::FAILED;
   DtlsConnectionState answerer_dtls_connection_state = DtlsConnectionState::FAILED;
@@ -348,166 +348,18 @@ dtls_quick_connection_dtls_client_test (bool useIpv6)
   releaseWebRtc (webRtcEpAnswerer);
 }
 
+
 static void
-send_pending_candidates (std::shared_ptr <WebRtcEndpointImpl> endpoint, std::list<kurento::OnIceCandidate> candidates, bool useIpv6)
+dtls_quick_connection_test_ipv6 ()
 {
-  GST_WARNING ("Pushing queued candidate");
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  std::for_each (candidates.begin(), candidates.end(), [endpoint, useIpv6](const OnIceCandidate event) {exchange_candidate (event, endpoint, useIpv6); });
-}
-
-static  void
-dtls_quick_connection_dtls_server_test (bool useIpv6)
-{
-  DtlsConnectionState offerer_dtls_connection_state = DtlsConnectionState::FAILED;
-  DtlsConnectionState answerer_dtls_connection_state = DtlsConnectionState::FAILED;
-  std::condition_variable cv;
-  std::mutex mtx;
-  std::unique_lock<std::mutex> lck (mtx);
-  uint64_t ice_gathering_started = 0;
-  uint64_t dtls_connection_started_offerer = 0;
-  uint64_t dtls_connection_started_answerer = 0;
-  uint64_t dtls_connection_connecting_offerer = 0;
-  uint64_t dtls_connection_connecting_answerer = 0;
-  uint64_t dtls_connection_connected_offerer = 0;
-  uint64_t dtls_connection_connected_answerer = 0;
-  std::list<kurento::OnIceCandidate> answerer_candidates = {};
-  std::shared_ptr<std::thread> async_deliver = NULL;
-
-  std::shared_ptr <WebRtcEndpointImpl> webRtcEpOfferer = createWebrtc();
-  std::shared_ptr <WebRtcEndpointImpl> webRtcEpAnswerer = createWebrtc();
-
-  webRtcEpOfferer->setName ("offerer");
-  webRtcEpAnswerer->setName ("answerer");
-
-  webRtcEpOfferer->signalOnIceCandidate.connect ([&] (OnIceCandidate event) {
-    exchange_candidate (event, webRtcEpAnswerer, useIpv6);
-  });
-
-  webRtcEpAnswerer->signalOnIceCandidate.connect ([&] (OnIceCandidate event) {
-    exchange_candidate (event, webRtcEpOfferer, useIpv6);
-    //answerer_candidates.push_back (event);
-  });
-
-//  webRtcEpOfferer->signalOnIceComponentStateChanged.connect ([&] (
-//  OnIceComponentStateChanged event) {
-//    ice_state_changed = true;
-//    cv.notify_one();
-//  });
-
-
-
-  webRtcEpAnswerer->signalIceComponentStateChange.connect ([&] (IceComponentStateChange event) {
-    std::shared_ptr<IceComponentState> state = event.getState ();
-
-    GST_WARNING ("Answerer ICE connection state change to %s", state->getString().c_str());
-  });
-  webRtcEpOfferer->signalIceComponentStateChange.connect ([&] (IceComponentStateChange event) {
-    std::shared_ptr<IceComponentState> state = event.getState ();
-
-    GST_WARNING ("Offerer ICE connection state change to %s", state->getString().c_str());
-  });
-  webRtcEpOfferer->signalDtlsConnectionStateChange.connect ([&] (
-    DtlsConnectionStateChange event) {
-      offerer_dtls_connection_state = *(event.getState());
-      GST_WARNING ("Offerer DTLS connect state change %s", offerer_dtls_connection_state.getString().c_str());
-      BOOST_TEST_MESSAGE("Offerer DTLS connection state: " + offerer_dtls_connection_state.getString() + " component: " + event.getComponentId() + " stream " + event.getStreamId());
-      // Using current KMS offerer is passive one so it gets to the NEW state immediately
-      if (offerer_dtls_connection_state.getValue() == DtlsConnectionState::NEW) {
-        dtls_connection_started_offerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      } else if (offerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTED) {
-        dtls_connection_connected_offerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        cv.notify_one();
-      } else if (offerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTING) {
-        dtls_connection_connecting_offerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      }
-    });
-
-
-  webRtcEpAnswerer->signalDtlsConnectionStateChange.connect ([&] (
-    DtlsConnectionStateChange event) {
-      answerer_dtls_connection_state = *(event.getState());
-      GST_WARNING ("Answerer DTLS connect state change %s", offerer_dtls_connection_state.getString().c_str());
-      BOOST_TEST_MESSAGE("Answerer DTLS connection state: " + answerer_dtls_connection_state.getString() + " component: " + event.getComponentId() + " stream " + event.getStreamId());
-      // Using current KMS answerer is active so its is-client is true and should only be reached after the ICE connection gets to 
-      // CONNECTED state with the feature we are testing.
-      if (answerer_dtls_connection_state.getValue() == DtlsConnectionState::NEW) {
-        dtls_connection_started_answerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        async_deliver = std::make_shared<std::thread>(send_pending_candidates, webRtcEpOfferer, answerer_candidates, useIpv6);
-//        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-//        std::for_each (answerer_candidates.begin(), answerer_candidates.end(), [webRtcEpAnswerer, useIpv6](const OnIceCandidate event) {exchange_candidate (event, webRtcEpAnswerer, useIpv6); });
-      } else if (answerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTED) {
-        dtls_connection_connected_answerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        cv.notify_one();
-      } else if (answerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTING) {
-        dtls_connection_connecting_answerer = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      }
-    });
-
-
-  std::string offer = webRtcEpOfferer->generateOffer ();
-  std::string answer = webRtcEpAnswerer->processOffer (offer);
-  webRtcEpOfferer->processAnswer (answer);
-
-
-  // Just to check the feature we wait for some seconds, if feature is not working, DTLS Hello should be triggered immediately and 
-  // as it is dropped (no valid candidate pair) exponential backoff will take place
-  // This delay just makes the ICE connection to take longer
-  // Although testing with delays is always a not so good idea, due to the dependencies it get about the conditions of the testing host
-  // in this case we are using it just to enhance the difference between the feature working (DTLS NEW state only reached after ICE connection 
-  // reaching CONNECTED state for answerer), and not working (NEW state reached immediately after processOffer is done on answerer)
-  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
-  ice_gathering_started = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-
-  webRtcEpOfferer->gatherCandidates ();
-  webRtcEpAnswerer->gatherCandidates ();
-
-  if (!cv.wait_for (lck, std::chrono::seconds (40000*TIMEOUT), [&] () {
-    return ((offerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTED) && (answerer_dtls_connection_state.getValue() == DtlsConnectionState::CONNECTED));
-  }) ) {
-    BOOST_ERROR ("Timeout waiting for ICE state change");
-  }
-
-  // Correct outcome is answerer DTLS NEW state reached after ICE gathering is started
-  // Incorrect outcome is answerer DTLS NEW state reached before ICE gathering is started
-  // Either case offerer DTLS NEW state should be reached before ICE gathering is started
-  if (dtls_connection_started_answerer <= ice_gathering_started) {
-    BOOST_ERROR ("DTLS quick connection is not working");
-  }
-  if (dtls_connection_started_offerer > ice_gathering_started) {
-    BOOST_ERROR ("This should not happen");
-  }
-
-  async_deliver->join ();
-  releaseWebRtc (webRtcEpOfferer);
-  releaseWebRtc (webRtcEpAnswerer);
+  dtls_quick_connection_test (true);
 }
 
 static void
-dtls_quick_connection_dtls_client_test_ipv6 ()
+dtls_quick_connection_test_ipv4 ()
 {
-  dtls_quick_connection_dtls_client_test (true);
+  dtls_quick_connection_test (false);
 }
-
-static void
-dtls_quick_connection_dtls_client_test_ipv4 ()
-{
-  dtls_quick_connection_dtls_client_test (false);
-}
-
-static void
-dtls_quick_connection_dtls_server_test_ipv6 ()
-{
-  dtls_quick_connection_dtls_server_test (true);
-}
-
-static void
-dtls_quick_connection_dtls_server_test_ipv4 ()
-{
-  dtls_quick_connection_dtls_server_test (false);
-}
-
-
 ******************************/
 
 static  void
@@ -992,10 +844,8 @@ init_unit_test_suite ( int , char *[] )
   test->add (BOOST_TEST_CASE ( &media_state_changes_ipv6 ), 0, /* timeout */ 15);
 
   /* These tests depend on GStreamer 1.17+ and feature on https://github.com/naevatec/kms-elements/tree/dtls-connection-state*/
-  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_dtls_client_test_ipv4), 0, /* timeout */ 15);
-  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_dtls_client_test_ipv6), 0, /* timeout */ 15); 
-  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_dtls_server_test_ipv4), 0, /* timeout */ 15);
-  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_dtls_server_test_ipv6), 0, /* timeout */ 15); 
+  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_test_ipv4), 0, /* timeout */ 15);
+  //test->add (BOOST_TEST_CASE (&dtls_quick_connection_test_ipv6), 0, /* timeout */ 15); 
   
   test->add (BOOST_TEST_CASE ( &connection_state_changes_ipv4 ),
              0, /* timeout */ 15);


### PR DESCRIPTION
Reverts Kurento/kms-elements#38

Reason: Code compiles but linker fails:

```
[ 40%] Linking C shared library libkmswebrtcendpointlib.so
CMakeFiles/kmswebrtcendpointlib.dir/kmswebrtctransportsink.c.o: In function `gst_bin_iterate_all_by_element_factory_name':
./src/gst-plugins/webrtcendpoint/./src/gst-plugins/webrtcendpoint/kmswebrtctransportsink.c:59: multiple definition of `gst_bin_iterate_all_by_element_factory_name'
CMakeFiles/kmswebrtcendpointlib.dir/kmswebrtctransportsrc.c.o:./src/gst-plugins/webrtcendpoint/./src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c:57: first defined here
collect2: error: ld returned 1 exit status
```
