### PR TITLE
Dtls server web rtc quick connection - fixed names collision

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbundleconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbundleconnection.c
@@ -93,6 +93,7 @@ kms_webrtc_bundle_connection_add (KmsIRtpConnection * base_rtp_conn,
   KmsWebRtcTransport *tr = priv->tr;
 
   kms_webrtc_transport_sink_set_dtls_is_client (tr->sink, active);
+  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcconnection.c
@@ -80,6 +80,7 @@ static void
 add_tr (KmsWebRtcTransport * tr, GstBin * bin, gboolean is_client)
 {
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, is_client);
+  kms_webrtc_transport_src_set_dtls_is_client (tr->src, is_client);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcrtcpmuxconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcrtcpmuxconnection.c
@@ -88,6 +88,7 @@ kms_webrtc_rtcp_mux_connection_add (KmsIRtpConnection * base_rtp_conn,
 
   /* srcs */
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, active);
+  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsctpconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsctpconnection.c
@@ -80,6 +80,7 @@ kms_webrtc_sctp_connection_add (KmsIRtpConnection * base_conn, GstBin * bin,
   KmsWebRtcTransport *tr = priv->tr;
 
   kms_webrtc_transport_sink_set_dtls_is_client(tr->sink, active);
+  kms_webrtc_transport_src_set_dtls_is_client (tr->src, active);
 
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (self->priv->tr->src)));
   gst_bin_add (bin, GST_ELEMENT (g_object_ref (self->priv->tr->sink)));

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsink.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsink.c
@@ -53,7 +53,7 @@ compare_factory_names (const GValue *velement, GValue *factory_name_val)
 }
 //
 // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4553-4574
-GstIterator *
+static GstIterator *
 gst_bin_iterate_all_by_element_factory_name (GstBin *bin,
     const gchar *factory_name)
 {

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
@@ -29,7 +29,85 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define kms_webrtc_transport_src_parent_class parent_class
 G_DEFINE_TYPE (KmsWebrtcTransportSrc, kms_webrtc_transport_src, GST_TYPE_BIN);
 
-#define SRTPDEC_NAME "srtp-decoder"
+#define SRTPDEC_FACTORY_NAME "srtpdec"
+
+
+// {{{{ FIXME: This can be deleted when we start using GStreamer >=1.18 for Kurento.
+// Code sourced from GStreamer/gstbin.c >=1.18
+//
+// https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4526-4537
+static gint
+compare_factory_names (const GValue *velement, GValue *factory_name_val)
+{
+  GstElement *element = g_value_get_object (velement);
+  GstElementFactory *factory = gst_element_get_factory (element);
+  const gchar *factory_name = g_value_get_string (factory_name_val);
+
+  if (factory == NULL)
+    return -1;
+
+  return g_strcmp0 (GST_OBJECT_NAME (factory), factory_name);
+}
+
+//
+// https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4553-4574
+GstIterator *
+gst_bin_iterate_all_by_element_factory_name (GstBin *bin,
+    const gchar *factory_name)
+{
+  GstIterator *children;
+  GstIterator *result;
+  GValue factory_name_val = G_VALUE_INIT;
+
+  g_return_val_if_fail (GST_IS_BIN (bin), NULL);
+  g_return_val_if_fail (factory_name && *factory_name, NULL);
+
+  g_value_init (&factory_name_val, G_TYPE_STRING);
+  g_value_set_string (&factory_name_val, factory_name);
+
+  children = gst_bin_iterate_recurse (bin);
+  result = gst_iterator_filter (children, (GCompareFunc)compare_factory_names,
+      &factory_name_val);
+
+  g_value_unset (&factory_name_val);
+
+  return result;
+}
+// }}}}
+
+static GstElement *
+kms_webrtc_transport_src_get_element_in_dtlssrtpdec (
+    KmsWebrtcTransportSrc *self,
+    const gchar *factory_name)
+{
+  GstElement *element = NULL;
+  GValue velement = G_VALUE_INIT;
+
+  GstIterator *iter = gst_bin_iterate_all_by_element_factory_name (
+      GST_BIN (self->dtlssrtpdec), factory_name);
+
+  if (gst_iterator_next (iter, &velement) == GST_ITERATOR_OK) {
+    // Assume only one element of the given type. This is the case in dtlssrtpdec.
+    element = g_value_dup_object (&velement);
+    g_value_reset (&velement);
+  }
+
+  if (gst_iterator_next (iter, &velement) != GST_ITERATOR_DONE) {
+    GST_WARNING_OBJECT (self,
+        "BUG: Several elements '%s' found in dtlssrtpdec; code assumes only one",
+        factory_name);
+  }
+
+  if (element == NULL) {
+    GST_WARNING_OBJECT (self, "BUG: Element '%s' not found in dtlssrtpdec",
+        factory_name);
+  }
+
+  g_value_unset (&velement);
+  gst_iterator_free (iter);
+
+  return element;
+}  
 
 static void
 kms_webrtc_transport_src_init (KmsWebrtcTransportSrc * self)
@@ -45,12 +123,12 @@ kms_webrtc_transport_src_connect_elements (KmsWebrtcTransportSrc * self)
   gst_bin_add_many (GST_BIN (self), self->src, self->dtlssrtpdec, NULL);
   gst_element_link (self->src, self->dtlssrtpdec);
 
-  srtpdec = gst_bin_get_by_name (GST_BIN (self->dtlssrtpdec), SRTPDEC_NAME);
+  srtpdec = kms_webrtc_transport_src_get_element_in_dtlssrtpdec (self, SRTPDEC_FACTORY_NAME);
   if (srtpdec != NULL) {
     g_object_set (srtpdec, "replay-window-size", RTP_RTX_SIZE, NULL);
     g_object_unref (srtpdec);
   } else {
-    GST_WARNING ("Cannot get srtpdec with name %s", SRTPDEC_NAME);
+    GST_WARNING ("Cannot get SRTP DTLS decoder");
   }
 }
 
@@ -77,12 +155,27 @@ kms_webrtc_transport_src_configure (KmsWebrtcTransportSrc * self,
   klass->configure (self, agent, stream_id, component_id);
 }
 
+void
+kms_webrtc_transport_src_set_dtls_is_client_default (KmsWebrtcTransportSrc * self,
+    gboolean is_client)
+{
+  // We just need to cache the DTLS client value for later use
+  self->dtls_client = is_client;  
+
+  if (is_client) {
+    GST_DEBUG_OBJECT(self, "Set as DTLS client (handshake initiator)");
+  } else {
+    GST_DEBUG_OBJECT(self, "Set as DTLS server (wait for handshake)");
+  }
+}
+
 static void
 kms_webrtc_transport_src_class_init (KmsWebrtcTransportSrcClass * klass)
 {
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
 
   klass->configure = kms_webrtc_transport_src_configure_default;
+  klass->set_dtls_is_client = kms_webrtc_transport_src_set_dtls_is_client_default;
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_DEFAULT_NAME, 0,
       GST_DEFAULT_NAME);
@@ -102,4 +195,14 @@ kms_webrtc_transport_src_new ()
   obj = g_object_new (KMS_TYPE_WEBRTC_TRANSPORT_SRC, NULL);
 
   return KMS_WEBRTC_TRANSPORT_SRC (obj);
+}
+
+void
+kms_webrtc_transport_src_set_dtls_is_client (KmsWebrtcTransportSrc * self,
+    gboolean is_client)
+{
+  KmsWebrtcTransportSrcClass *klass =
+      KMS_WEBRTC_TRANSPORT_SRC_CLASS (G_OBJECT_GET_CLASS (self));
+
+  klass->set_dtls_is_client (self, is_client);
 }

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.c
@@ -51,7 +51,7 @@ compare_factory_names (const GValue *velement, GValue *factory_name_val)
 
 //
 // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/10f72da5040b74678c8f81723971127ee8bee04f/subprojects/gstreamer/gst/gstbin.c#L4553-4574
-GstIterator *
+static GstIterator *
 gst_bin_iterate_all_by_element_factory_name (GstBin *bin,
     const gchar *factory_name)
 {

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrc.h
@@ -45,6 +45,8 @@ struct _KmsWebrtcTransportSrc
   GstElement *src;
   GstElement *dtlssrtpdec;
   gulong src_probe;
+
+  gboolean dtls_client;
 };
 
 struct _KmsWebrtcTransportSrcClass
@@ -56,6 +58,10 @@ struct _KmsWebrtcTransportSrcClass
                          KmsIceBaseAgent *agent,
                          const char *stream_id,
                          guint component_id);
+
+  void (*set_dtls_is_client) (KmsWebrtcTransportSrc * self,
+                          gboolean is_client);
+
 };
 
 GType kms_webrtc_transport_src_get_type (void);
@@ -66,6 +72,9 @@ void kms_webrtc_transport_src_configure (KmsWebrtcTransportSrc * self,
                                              KmsIceBaseAgent *agent,
                                              const char *stream_id,
                                              guint component_id);
+
+void kms_webrtc_transport_src_set_dtls_is_client (KmsWebrtcTransportSrc *src, 
+                                                  gboolean is_client);
 
 G_END_DECLS
 #endif /* __KMS_WEBRTC_TRANSPORT_SRC_H__ */

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
@@ -91,8 +91,7 @@ store_pending_dtls_buffer (GstBuffer **buffer, guint idx, gpointer user_data)
     GST_DEBUG_OBJECT (self, "Storing DTLS buffer until ICE is CONNECTED");
     self->priv->pending_buffers = g_list_append (self->priv->pending_buffers, *buffer);
 
-    // Side effect: Unref and remove the buffer from its buffer list, if any.
-    gst_buffer_unref (*buffer);
+    // Side effect: Remove the buffer from its buffer list, if any.
     *buffer = NULL;
   }
 
@@ -129,7 +128,6 @@ kms_webrtc_transport_src_nice_send_pending_buffer (GstBuffer *buffer, KmsWebrtcT
   GstPad *nicesrc_src = gst_element_get_static_pad (self->src, "src");
 
   if (gst_pad_push (nicesrc_src, buffer) == GST_FLOW_ERROR ) {
-    gst_buffer_unref (buffer);
     GST_INFO_OBJECT (self, "Cannot deliver delayed buffer");
   } else {
     GST_DEBUG_OBJECT (self, "Delivered delayed buffer");
@@ -232,7 +230,6 @@ kms_webrtc_transport_src_nice_block_dtls_until_ice_connected (GstPad *pad, GstPa
     GstBuffer *buffer = gst_pad_probe_info_get_buffer (info);
 
     if (buffer != NULL) {
-      gst_buffer_ref (buffer);
       store_pending_dtls_buffer (&buffer, 0, self);
 
       if (buffer == NULL) {

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
@@ -29,17 +29,129 @@
 GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
 #define kms_webrtc_transport_src__nice_parent_class parent_class
-G_DEFINE_TYPE (KmsWebrtcTransportSrcNice, kms_webrtc_transport_src_nice,
-    KMS_TYPE_WEBRTC_TRANSPORT_SRC);
+
+#define KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK(src_nice) \
+  (g_rec_mutex_lock (&(src_nice)->priv->mutex))
+
+#define KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK(src_nice) \
+  (g_rec_mutex_unlock (&(src_nice)->priv->mutex))
+
+#define KMS_WEBRTC_TRANSPORT_SRC_NICE_GET_PRIVATE(obj) ( \
+  G_TYPE_INSTANCE_GET_PRIVATE (                       \
+    (obj),                                            \
+    KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,                  \
+    KmsWebrtcTransportSrcNicePrivate                    \
+  )                                                   \
+)
+
+struct _KmsWebrtcTransportSrcNicePrivate
+{
+  GRecMutex mutex;
+
+  gboolean pending_buffers_delivered;
+
+  GList *pending_buffers;
+};
+
+G_DEFINE_TYPE_WITH_CODE (KmsWebrtcTransportSrcNice, kms_webrtc_transport_src_nice, KMS_TYPE_WEBRTC_TRANSPORT_SRC,
+    G_ADD_PRIVATE (KmsWebrtcTransportSrcNice));
 
 static void
 kms_webrtc_transport_src_nice_init (KmsWebrtcTransportSrcNice * self)
 {
   KmsWebrtcTransportSrc *parent = KMS_WEBRTC_TRANSPORT_SRC (self);
 
+  self->priv = KMS_WEBRTC_TRANSPORT_SRC_NICE_GET_PRIVATE (self);
   parent->src = gst_element_factory_make ("nicesrc", NULL);
 
   kms_webrtc_transport_src_connect_elements (parent);
+}
+
+static void
+kms_webrtc_transport_src_nice_finalize (GObject * object)
+{
+  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (object);
+
+  if (self->priv->pending_buffers != NULL) {
+    g_list_free_full (self->priv->pending_buffers, (GDestroyNotify)gst_buffer_unref);
+    self->priv->pending_buffers = NULL;
+  }
+}
+
+static void
+kms_webrtc_transport_src_nice_send_pending_buffer (GstBuffer *buffer, KmsWebrtcTransportSrc *self)
+{
+  GstPad *nicesrc_src = gst_element_get_static_pad (self->src, "src");
+
+  if (gst_pad_push (nicesrc_src, buffer) == GST_FLOW_ERROR ) {
+    gst_buffer_unref (buffer);
+    GST_INFO_OBJECT (self, "Cannot deliver delayed buffer");
+  } else {
+    GST_DEBUG_OBJECT (self, "Delivered delayed buffer");
+  }
+  gst_object_unref (nicesrc_src);
+}
+
+
+static gboolean 
+do_send_pending_buffers (GstClock * clock,
+                     GstClockTime time,
+                     GstClockID id,
+                     gpointer user_data)
+{
+  GList *pending_buffers;
+  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (user_data);
+
+  KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
+  pending_buffers = self->priv->pending_buffers;
+  self->priv->pending_buffers = NULL;
+  KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
+
+  if (pending_buffers != NULL) {
+    g_list_foreach (pending_buffers, (GFunc) kms_webrtc_transport_src_nice_send_pending_buffer, self);
+    g_list_free (pending_buffers);
+  }
+  return TRUE;
+}
+
+static void
+kms_webrtc_transport_src_nice_component_state_changed (KmsIceBaseAgent * agent,
+    char *stream_id, guint component_id, IceState state,
+    KmsWebrtcTransportSrcNice * self)
+{
+  gboolean is_client;
+  KmsWebrtcTransportSrc *parent = KMS_WEBRTC_TRANSPORT_SRC(self);
+
+  GST_LOG_OBJECT (self,
+      "[IceComponentStateChanged] state: %s, stream_id: %s, component_id: %u",
+      kms_ice_base_agent_state_to_string (state), stream_id, component_id);
+
+  is_client = parent->dtls_client;
+
+  if (state == ICE_STATE_CONNECTED) {
+    if (!is_client) {
+      // Send all pending buffer, if any and signal probe to be removed on next Buffer
+      KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
+      self->priv->pending_buffers_delivered = TRUE;
+      KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
+
+      // we have observed that if we immediately send the delayed buffer, and the openssl negotiation process starts, the server hello gets the nicesink not ready yet
+      // to send, so to avoid that we delayed the sending by 10 ms
+      if (self->priv->pending_buffers != NULL) {
+        GstClockTime now;
+        GstClockTime filter_time;
+        GstClockID filter_time_id;
+        GstClock *clock;
+
+        clock = gst_element_get_clock (parent->src);
+        now = gst_clock_get_time (clock);
+        filter_time = now + (GST_SECOND / 100);
+        filter_time_id = gst_clock_new_single_shot_id (clock, filter_time);
+        gst_clock_id_wait_async (filter_time_id, do_send_pending_buffers, gst_object_ref (self), gst_object_unref);
+        gst_object_unref (clock);
+      }
+    }
+  }
 }
 
 void
@@ -52,17 +164,97 @@ kms_webrtc_transport_src_nice_configure (KmsWebrtcTransportSrc * self,
   g_object_set (G_OBJECT (self->src),
       "agent", kms_ice_nice_agent_get_agent (nice_agent),
       "stream", id, "component", component_id, NULL);
+
+  g_signal_connect (nice_agent, "on-ice-component-state-changed",
+    G_CALLBACK (kms_webrtc_transport_src_nice_component_state_changed), self);
+}
+
+static gboolean
+append_pending_buffer (GstBuffer **buffer, guint idx, gpointer user_data)
+{
+  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE (user_data);
+
+  self->priv->pending_buffers = g_list_append (self->priv->pending_buffers, *buffer);
+
+  return TRUE;
+}
+
+
+static GstPadProbeReturn
+kms_webrtc_transport_src_nice_block_till_ice_connected (GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
+{
+  KmsWebrtcTransportSrcNice *self = KMS_WEBRTC_TRANSPORT_SRC_NICE(user_data);
+
+  KMS_WEBRTC_TRANSPORT_SRC_NICE_LOCK (self);
+  if (self->priv->pending_buffers_delivered){
+    KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
+    GST_DEBUG_OBJECT (self, "No more possible buffers pending, removing probe");
+    return GST_PAD_PROBE_REMOVE;
+  }
+
+  if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER ) {
+    // Cache buffer for later delivery when ICE gets to CONNECTED
+    GstBuffer *buffer = gst_pad_probe_info_get_buffer (info);
+
+    //buffer = gst_buffer_ref (buffer);
+    if (buffer != NULL) {
+      append_pending_buffer (&buffer, 0, self);
+      GST_DEBUG_OBJECT (self, "Added buffer to be delivered when ICE gets CONNECTED, probably a DTLS connection handshake packet");
+    }
+  }
+
+  if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER_LIST) {
+    GstBufferList *buffer_list = gst_pad_probe_info_get_buffer_list (info);
+
+    if (buffer_list != NULL) {
+      gst_buffer_list_foreach (buffer_list, append_pending_buffer, self);
+      GST_DEBUG_OBJECT (self, "Added buffer list to be delivered when ICE gets CONNECTED, probably a DTLS conneciton handshake packet");
+    }
+  }
+  KMS_WEBRTC_TRANSPORT_SRC_NICE_UNLOCK (self);
+
+  return GST_PAD_PROBE_HANDLED;
+}
+
+
+
+static void
+kms_webrtc_transport_src_nice_set_dtls_is_client (KmsWebrtcTransportSrc * src,
+    gboolean is_client)
+{
+  KmsWebrtcTransportSrcNiceClass *klass = 
+      KMS_WEBRTC_TRANSPORT_SRC_NICE_CLASS (G_OBJECT_GET_CLASS (src));
+  KmsWebrtcTransportSrcClass *parent_klass =
+      KMS_WEBRTC_TRANSPORT_SRC_CLASS  (g_type_class_peek_parent(klass));
+
+  parent_klass->set_dtls_is_client (src, is_client);
+
+  if (!is_client) {
+    // If is DTLS server (!is_client)
+    //    install a blocking probe in dtlssrtpdec sink pad
+    //    Blocking probe should buffer all GstBuffers sent to sink pad in dtlssrtpdec
+    //    Then when ICE gets to CONNECTED state it should resend all pending buffers
+    GstPad *nicesrc_src = gst_element_get_static_pad (src->src, "src");
+
+    gst_pad_add_probe (nicesrc_src, GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_BUFFER_LIST,  
+                      kms_webrtc_transport_src_nice_block_till_ice_connected, src, NULL);
+    gst_object_unref (nicesrc_src);
+  }
+ 
 }
 
 static void
 kms_webrtc_transport_src_nice_class_init (KmsWebrtcTransportSrcNiceClass *
     klass)
 {
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
   KmsWebrtcTransportSrcClass *base_class;
 
+  gobject_class->finalize = kms_webrtc_transport_src_nice_finalize;
   base_class = KMS_WEBRTC_TRANSPORT_SRC_CLASS (klass);
   base_class->configure = kms_webrtc_transport_src_nice_configure;
+  base_class->set_dtls_is_client = kms_webrtc_transport_src_nice_set_dtls_is_client;
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_DEFAULT_NAME, 0,
       GST_DEFAULT_NAME);

--- a/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.h
@@ -28,7 +28,7 @@ G_BEGIN_DECLS
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST((obj),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,KmsWebrtcTransportSrcNice))
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST((klass),KMS_TYPE_WEBRTC_TRANSPORT_SRCNICE,KmsWebrtcTransportSrcNiceClass))
+  (G_TYPE_CHECK_CLASS_CAST((klass),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE,KmsWebrtcTransportSrcNiceClass))
 #define KMS_IS_WEBRTC_TRANSPORT_SRC_NICE(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),KMS_TYPE_WEBRTC_TRANSPORT_SRC_NICE))
 #define KMS_IS_WEBRTC_TRANSPORT_SRC_NICE_CLASS(klass) \
@@ -36,11 +36,14 @@ G_BEGIN_DECLS
 #define KMS_WEBRTC_TRANSPORT_SRC_NICE_CAST(obj) ((KmsWebrtcTransportSrcNice*)(obj))
 
 typedef struct _KmsWebrtcTransportSrcNice KmsWebrtcTransportSrcNice;
+typedef struct _KmsWebrtcTransportSrcNicePrivate KmsWebrtcTransportSrcNicePrivate;
 typedef struct _KmsWebrtcTransportSrcNiceClass KmsWebrtcTransportSrcNiceClass;
 
 struct _KmsWebrtcTransportSrcNice
 {
   KmsWebrtcTransportSrc parent;
+
+  KmsWebrtcTransportSrcNicePrivate *priv;
 };
 
 struct _KmsWebrtcTransportSrcNiceClass


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
This change is related to a previous PR in https://github.com/Kurento/kms-elements/pull/37
More specifically this change covers a use case not covered in the previous PR. This is as follows:

 - When Kurento is set as DTLS server it may happen that the remote peer of the WebRTC connection reaches to ICE connected state before Kurento does. 
 - The problem appears when not only the remote peer gets ICE connected before but when the peer sends the DTLS Client Hello and it arrives before the WebRTCEndpoint in Kurento has reached the ICE connected state. 
 - If this happens, the DTLS Client hello is received in the nicesrc element from the Webrtctransportsrc and it is relayed to the dtlssrtpdec element. This in turns starts DTLS handshake and sends back a DTLS Server hello to the nicesink element. But, and this is the real problem, the nicesink finds the ICE connection not yet established and silently drops the DTLS server hello.
 - When the DTLS timeout is up (1 second this first time, but doubling each time), the endpoint will resend again the DTLS server hello packet, and hopefully this time it will find the ICE connection established and the DTLS server hello will be delivered to the remote peer. If not, it will try again on the next timeout. 
 - The problem is that each timeout introduces some additional delay in the WebRTC connection establishment. 
 - In many cases  that we have observed, the DTLS Client hello just arrives a few milliseconds before the ICE gets CONNECTED in WebRTCEndpoint. But the impact is that those few miliseconds will make the connection to delay around 1 second. 

This problem has a lesser impact than the previous PR, but in the end it is worth improving it.

## What is the new behavior provided by this change?
 - This change only takes effect when the WebRTCEndpoint is configured as DTLS server (waiter for DTLS handshake)
 - It just captures all packets coming from the nicesrc element to the dtlssrpdec and stores them until the ICE gets connected. 
 - A signal is connected so that when ICE connection changes state, and the new state is connected, it gets the temporary stored buffers and delivers them to the dtlssrtpdec element, thus ensuring the DTLS handshake process only takes place when the ICE connection is established.

According to our observations there is only one possible buffer stored that corresponds to the DTLS Client hello received from remote peer. Also, we noticed that if in the same call that notifies ICE connection we delivered the stored DTLS client hello, the answer (DTLS server hello) still finds the ICE connection not usable, so to avoid that, we just make that delivery asynchronously in a separate thread 10 ms later.

## How has this been tested?
IT has been tested with automatic tests that cannot yet be used in this Kurento version as they need GStreamer 1.18 to work.
We have also tested it in real environmentes capturing network traffic to see that the change causes the desired behaviour.

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [Contribution Guidelines](https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md)
- [X] I have added an explanation of what the changes do and why they should be included
- [X] I have written new tests for the changes, as applicable, and have successfully run them locally

