### PR TITLE
Feature/webrtc qos dscp

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
+++ b/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
@@ -43,6 +43,7 @@ struct _KmsIceNiceAgentPrivate
   GMainContext *context;
   NiceAgent *agent;
   GSList *remote_candidates;
+  gint qos_dscp;
 };
 
 static char *
@@ -362,7 +363,7 @@ end:
 // ----------------------------------------------------------------------------
 
 KmsIceNiceAgent *
-kms_ice_nice_agent_new (GMainContext * context)
+kms_ice_nice_agent_new (GMainContext * context, gint qos_dscp)
 {
   GObject *obj;
   KmsIceNiceAgent *self;
@@ -370,6 +371,7 @@ kms_ice_nice_agent_new (GMainContext * context)
   obj = g_object_new (KMS_TYPE_ICE_NICE_AGENT, NULL);
   self = KMS_ICE_NICE_AGENT (obj);
   self->priv->context = context;
+  self->priv->qos_dscp = qos_dscp;
 
   GST_DEBUG_OBJECT (self, "Create new instance, compatibility level: RFC5245");
   self->priv->agent =
@@ -440,6 +442,11 @@ kms_ice_nice_agent_add_stream (KmsIceBaseAgent * self, const char *stream_id,
   for (i = 1; i <= KMS_NICE_N_COMPONENTS; i++) {
     nice_agent_set_port_range (nice_agent->priv->agent, id, i, min_port,
         max_port);
+  }
+
+  if (nice_agent->priv->qos_dscp >= 0) {
+    GST_LOG_OBJECT (self, "Setting DSCP tag %d for stream %u - %s", nice_agent->priv->qos_dscp, id, stream_id);
+    nice_agent_set_stream_tos (nice_agent->priv->agent, id, nice_agent->priv->qos_dscp);
   }
 
   // NOTE: Docs say [0] that an I/O callback must be registered in order to receive

--- a/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
+++ b/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
@@ -445,8 +445,14 @@ kms_ice_nice_agent_add_stream (KmsIceBaseAgent * self, const char *stream_id,
   }
 
   if (nice_agent->priv->qos_dscp >= 0) {
+    gint tos;
+
     GST_LOG_OBJECT (self, "Setting DSCP tag %d for stream %u - %s", nice_agent->priv->qos_dscp, id, stream_id);
-    nice_agent_set_stream_tos (nice_agent->priv->agent, id, nice_agent->priv->qos_dscp);
+    
+    /* Extract and shift 6 bits of DSFIELD */
+    tos = (nice_agent->priv->qos_dscp & 0x3f) << 2;
+
+    nice_agent_set_stream_tos (nice_agent->priv->agent, id, tos);
   }
 
   // NOTE: Docs say [0] that an I/O callback must be registered in order to receive

--- a/src/gst-plugins/webrtcendpoint/kmsiceniceagent.h
+++ b/src/gst-plugins/webrtcendpoint/kmsiceniceagent.h
@@ -54,7 +54,7 @@ struct _KmsIceNiceAgentClass
 
 GType kms_ice_nice_agent_get_type (void);
 
-KmsIceNiceAgent *kms_ice_nice_agent_new (GMainContext * context);
+KmsIceNiceAgent *kms_ice_nice_agent_new (GMainContext * context, gint qos_dscp);
 NiceAgent* kms_ice_nice_agent_get_agent (KmsIceNiceAgent* agent);
 
 G_END_DECLS

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
@@ -59,6 +59,7 @@ G_DEFINE_TYPE (KmsWebrtcEndpoint, kms_webrtc_endpoint,
 #define DEFAULT_EXTERNAL_IPV4 NULL
 #define DEFAULT_EXTERNAL_IPV6 NULL
 #define DEFAULT_ICE_TCP TRUE
+#define DEFAULT_QOS_DSCP -1
 
 enum
 {
@@ -72,6 +73,7 @@ enum
   PROP_EXTERNAL_IPV4,
   PROP_EXTERNAL_IPV6,
   PROP_ICE_TCP,
+  PROP_QOS_DSCP,
   N_PROPERTIES
 };
 
@@ -108,6 +110,7 @@ struct _KmsWebrtcEndpointPrivate
   gchar *external_ipv4;
   gchar *external_ipv6;
   gboolean ice_tcp;
+  gint qos_dscp;
 };
 
 /* Internal session management begin */
@@ -321,7 +324,7 @@ kms_webrtc_endpoint_create_session_internal (KmsBaseSdpEndpoint * base_sdp,
   KmsWebrtcSession *webrtc_sess;
 
   webrtc_sess =
-      kms_webrtc_session_new (base_sdp, id, manager, self->priv->context);
+      kms_webrtc_session_new (base_sdp, id, manager, self->priv->context, self->priv->qos_dscp);
 
   callbacks.add_pad_cb = kms_webrtc_endpoint_add_pad;
   callbacks.remove_pad_cb = kms_webrtc_endpoint_remove_pad;
@@ -545,6 +548,9 @@ kms_webrtc_endpoint_set_property (GObject * object, guint prop_id,
     case PROP_ICE_TCP:
       self->priv->ice_tcp = g_value_get_boolean (value);
       break;
+  	case PROP_QOS_DSCP:
+	  	self->priv->qos_dscp = g_value_get_int (value);
+		  break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -589,6 +595,9 @@ kms_webrtc_endpoint_get_property (GObject * object, guint prop_id,
     case PROP_ICE_TCP:
       g_value_set_boolean (value, self->priv->ice_tcp);
       break;
+  	case PROP_QOS_DSCP:
+	  	g_value_set_int (value, self->priv->qos_dscp);
+		  break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -833,6 +842,12 @@ kms_webrtc_endpoint_class_init (KmsWebrtcEndpointClass * klass)
         "iceTcp",
         "Enable ICE-TCP candidate gathering",
         DEFAULT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_QOS_DSCP,
+      g_param_spec_int ("qos-dscp",
+          "QoS DSCP", "Set to assign DSCP value for network traffice sent",
+		  -1, G_MAXINT, DEFAULT_QOS_DSCP,
+		  G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   /**
   * KmsWebrtcEndpoint::on-ice-candidate:

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcendpoint.c
@@ -845,7 +845,7 @@ kms_webrtc_endpoint_class_init (KmsWebrtcEndpointClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_QOS_DSCP,
       g_param_spec_int ("qos-dscp",
-          "QoS DSCP", "Set to assign DSCP value for network traffice sent",
+          "QoS DSCP", "Set to assign DSCP value for network traffic sent",
 		  -1, G_MAXINT, DEFAULT_QOS_DSCP,
 		  G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
@@ -184,13 +184,14 @@ connect_sctp_data_new (KmsWebrtcSession * self, GstSDPMedia * media,
 
 KmsWebrtcSession *
 kms_webrtc_session_new (KmsBaseSdpEndpoint * ep, guint id,
-    KmsIRtpSessionManager * manager, GMainContext * context)
+    KmsIRtpSessionManager * manager, GMainContext * context, gint qos_dscp)
 {
   GObject *obj;
   KmsWebrtcSession *self;
 
   obj = g_object_new (KMS_TYPE_WEBRTC_SESSION, NULL);
   self = KMS_WEBRTC_SESSION (obj);
+  self->qos_dscp = qos_dscp;
   KMS_WEBRTC_SESSION_CLASS (G_OBJECT_GET_CLASS (self))->post_constructor
       (self, ep, id, manager, context);
 
@@ -1906,7 +1907,7 @@ kms_webrtc_session_new_selected_pair_full (KmsIceBaseAgent * agent,
 static void
 kms_webrtc_session_init_ice_agent (KmsWebrtcSession * self)
 {
-  self->agent = KMS_ICE_BASE_AGENT (kms_ice_nice_agent_new (self->context));
+  self->agent = KMS_ICE_BASE_AGENT (kms_ice_nice_agent_new (self->context, self->qos_dscp));
 
   kms_ice_base_agent_run_agent (self->agent);
 

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
@@ -79,6 +79,8 @@ struct _KmsWebrtcSession
   guint16 min_port;
   guint16 max_port;
 
+  gint qos_dscp;
+
   gboolean gather_started;
 
   GstElement *data_session;
@@ -119,7 +121,8 @@ GType kms_webrtc_session_get_type (void);
 
 KmsWebrtcSession * kms_webrtc_session_new (KmsBaseSdpEndpoint * ep, guint id,
 					   KmsIRtpSessionManager * manager,
-                                           GMainContext * context);
+                                           GMainContext * context, 
+                                           gint qos_dscp);
 
 KmsWebRtcBaseConnection * kms_webrtc_session_get_connection (KmsWebrtcSession * self, KmsSdpMediaHandler * handler);
 gboolean kms_webrtc_session_set_ice_credentials (KmsWebrtcSession * self, KmsSdpMediaHandler *handler, GstSDPMedia *media);

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -147,7 +147,7 @@
 ;; This in turn may make intermediate routers to adapt ist traffic handling for those packets 
 ;; according to the DSCP value set.
 ;; Recommended values for WebRTc traffic are indicated in section 5 of RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5
-;; Mainly the following ones, although al other standard defined SDCP value codes can be applied as 
+;; Mainly the following ones, although all other standard defined DSCP value codes can be applied as 
 ;; currently registered in IANA : http://www.iana.org/assignments/dscp-registry/dscp-registry.xml
 ;; This feature needs to be managed with caution, as intermediate routers are not guaranteed to support it and also
 ;; as specified in RFC 8837, some routers may block traffic with certain DSCP values
@@ -170,8 +170,8 @@
 ;;     |          Data         |  LE (1)  |  DF |    AF11    |    AF21    |
 ;;     |                       |          | (0) |            |            |
 ;;     +-----------------------+----------+-----+------------+------------+
-;; This only contemplates outgoing network packets form KMS, to complete the solution, DSCP must be also 
+;; This only covers outgoing network packets form KMS, to complete the solution, DSCP must be also 
 ;; requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
-;; browser or client. Ob broeser the client application needs to use the following API 
+;; browser or client. On browser, the client application needs to use the following API 
 ;; https://www.w3.org/TR/webrtc-priority/
-;
+;qos-dscp=AUDIO_HIGH

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -140,3 +140,38 @@
 ;; <iceTcp> is either 1 (ON) or 0 (OFF). Default: 1 (ON).
 ;;
 ;iceTcp=1
+
+;; Enable DSCP tagging for QoS management
+;; WebRTCEndpoints that have this property set to a value different from NO_VALUE
+;; will have its output network packets tagged with the corresponding DSCP value
+;; This in turn may make intermediate routers to adapt ist traffic handling for those packets 
+;; according to the DSCP value set.
+;; Recommended values for WebRTc traffic are indicated in section 5 of RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5
+;; Mainly the following ones, although al other standard defined SDCP value codes can be applied as 
+;; currently registered in IANA : http://www.iana.org/assignments/dscp-registry/dscp-registry.xml
+;; This feature needs to be managed with caution, as intermediate routers are not guaranteed to support it and also
+;; as specified in RFC 8837, some routers may block traffic with certain DSCP values
+;;
+;;     +=======================+==========+=====+============+============+
+;;     |       Flow Type       | Very Low | Low |   Medium   |    High    |
+;;     +=======================+==========+=====+============+============+
+;;     |         Audio         |  LE (1)  |  DF |  EF (46)   |  EF (46)   |
+;;     |                       |          | (0) |            |            |
+;;     +-----------------------+----------+-----+------------+------------+
+;;     +-----------------------+----------+-----+------------+------------+
+;;     |   Interactive Video   |  LE (1)  |  DF | AF42, AF43 | AF41, AF42 |
+;;     | with or without Audio |          | (0) |  (36, 38)  |  (34, 36)  |
+;;     +-----------------------+----------+-----+------------+------------+
+;;     +-----------------------+----------+-----+------------+------------+
+;;     | Non-Interactive Video |  LE (1)  |  DF | AF32, AF33 | AF31, AF32 |
+;;     | with or without Audio |          | (0) |  (28, 30)  |  (26, 28)  |
+;;     +-----------------------+----------+-----+------------+------------+
+;;     +-----------------------+----------+-----+------------+------------+
+;;     |          Data         |  LE (1)  |  DF |    AF11    |    AF21    |
+;;     |                       |          | (0) |            |            |
+;;     +-----------------------+----------+-----+------------+------------+
+;; This only contemplates outgoing network packets form KMS, to complete the solution, DSCP must be also 
+;; requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
+;; browser or client. Ob broeser the client application needs to use the following API 
+;; https://www.w3.org/TR/webrtc-priority/
+;

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -141,12 +141,12 @@
 ;;
 ;iceTcp=1
 
-;; Enable DSCP tagging for QoS management
+;; Enable DSCP tagging for QoS management.
 ;; WebRTCEndpoints that have this property set to a value different from NO_VALUE
-;; will have its output network packets tagged with the corresponding DSCP value
-;; This in turn may make intermediate routers to adapt ist traffic handling for those packets 
+;; will have its output network packets tagged with the corresponding DSCP value.
+;; This in turn may make intermediate routers to adapt their traffic handling for those packets 
 ;; according to the DSCP value set.
-;; Recommended values for WebRTc traffic are indicated in section 5 of RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5
+;; Recommended values for WebRTC traffic are indicated in section 5 of RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5
 ;; Mainly the following ones, although all other standard defined DSCP value codes can be applied as 
 ;; currently registered in IANA : http://www.iana.org/assignments/dscp-registry/dscp-registry.xml
 ;; This feature needs to be managed with caution, as intermediate routers are not guaranteed to support it and also
@@ -171,7 +171,7 @@
 ;;     |                       |          | (0) |            |            |
 ;;     +-----------------------+----------+-----+------------+------------+
 ;; This only covers outgoing network packets form KMS, to complete the solution, DSCP must be also 
-;; requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
+;; requested on client, unfortunately for traffic on the other direction, this must be requested to the 
 ;; browser or client. On browser, the client application needs to use the following API 
 ;; https://www.w3.org/TR/webrtc-priority/
 ;qos-dscp=AUDIO_HIGH

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -599,9 +599,11 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
     }
   }
 
-  if (qosDscp->getValue () != DSCPValue::NO_VALUE) {
+  if ((qosDscp->getValue () != DSCPValue::NO_VALUE) && (qosDscp->getValue() != DSCPValue::NO_DSCP)) {
     GST_INFO ("Setting QOS-DSCP value to %s", qosDscp->getString().c_str());
     g_object_set (element, "qos-dscp", get_dscp_value (qosDscp), NULL);
+  } else {
+    GST_INFO ("No QOS-DSCP value set");
   }
 
 

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -43,6 +43,8 @@
 
 #include <CertificateManager.hpp>
 
+#include <DSCPValue.hpp>
+
 #define GST_CAT_DEFAULT kurento_web_rtc_endpoint_impl
 GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define GST_DEFAULT_NAME "KurentoWebRtcEndpointImpl"
@@ -63,6 +65,8 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define PROP_EXTERNAL_IPV6 "external-ipv6"
 #define PROP_NETWORK_INTERFACES "network-interfaces"
 #define PROP_ICE_TCP "ice-tcp"
+
+#define PARAM_QOS_DSCP "qos-dscp"
 
 namespace kurento
 {
@@ -487,11 +491,97 @@ WebRtcEndpointImpl::getCerficateFromFile (std::string &path)
   return certificate;
 }
 
+static gint
+get_dscp_value (std::shared_ptr<DSCPValue> qosDscp)
+{
+  switch (qosDscp->getValue ())
+  {
+  case DSCPValue::CS0:
+    return 0;
+  case DSCPValue::CS1:
+    return 8;
+  case DSCPValue::CS2:
+    return 16;
+  case DSCPValue::CS3:
+    return 24;
+  case DSCPValue::CS4:
+    return 32;
+  case DSCPValue::CS5:
+    return 40;
+  case DSCPValue::CS6:
+    return 48;
+  case DSCPValue::CS7:
+    return 56;
+  case DSCPValue::AF11:
+    return 10;
+  case DSCPValue::AF12:
+    return 12;
+  case DSCPValue::AF13:
+    return 14;
+  case DSCPValue::AF21:
+    return 18;
+  case DSCPValue::AF22:
+    return 20;
+  case DSCPValue::AF23:
+    return 22;
+  case DSCPValue::AF31:
+    return 26;
+  case DSCPValue::AF32:
+    return 28;
+  case DSCPValue::AF33:
+    return 30;
+  case DSCPValue::AF41:
+    return 34;
+  case DSCPValue::AF42:
+    return 36;
+  case DSCPValue::AF43:
+    return 38;
+  case DSCPValue::EF:
+    return 46;
+  case DSCPValue::VOICEADMIT:
+    return 44;
+  case DSCPValue::LE:
+    return 1;
+  case DSCPValue::AUDIO_VERYLOW:
+    return 1;
+  case DSCPValue::AUDIO_LOW:
+    return 0;
+  case DSCPValue::AUDIO_MEDIUM:
+    return 46;
+  case DSCPValue::AUDIO_HIGH:
+    return 46;
+  case DSCPValue::VIDEO_VERYLOW:
+    return 1;
+  case DSCPValue::VIDEO_LOW:
+    return 0;
+  case DSCPValue::VIDEO_MEDIUM:
+    return 36;
+  case DSCPValue::VIDEO_MEDIUM_THROUGHPUT:
+    return 38;
+  case DSCPValue::VIDEO_HIGH:
+    return 36;
+  case DSCPValue::VIDEO_HIGH_THROUGHPUT:
+    return 34;
+  case DSCPValue::DATA_VERYLOW:
+    return 1;
+  case DSCPValue::DATA_LOW:
+    return 0;
+  case DSCPValue::DATA_MEDIUM:
+    return 10;
+  case DSCPValue::DATA_HIGH:
+    return 18;
+  default:
+    return -1;
+  }
+}
+
+
 WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
                                         std::shared_ptr<MediaPipeline>
                                         mediaPipeline, bool recvonly,
                                         bool sendonly, bool useDataChannels,
-                                        std::shared_ptr<CertificateKeyType> certificateKeyType) :
+                                        std::shared_ptr<CertificateKeyType> certificateKeyType, 
+                                        std::shared_ptr<DSCPValue> qosDscp) :
   BaseRtpEndpointImpl (conf,
                        std::dynamic_pointer_cast<MediaObjectImpl>
                        (mediaPipeline), FACTORY_NAME)
@@ -499,6 +589,21 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
   std::call_once (check_openh264, check_support_for_h264);
   std::call_once (certificates_flag,
                   std::bind (&WebRtcEndpointImpl::generateDefaultCertificates, this) );
+
+  this->qosDscp = qosDscp;
+  if (qosDscp->getValue () == DSCPValue::NO_VALUE) {
+    std::string cfg_dscp_value;
+    if (getConfigValue<std::string,WebRtcEndpoint>(&cfg_dscp_value, PARAM_QOS_DSCP)) {
+      GST_INFO ("QOS-DSCP default configured value is %s", cfg_dscp_value.c_str());
+      qosDscp = std::make_shared<DSCPValue> (cfg_dscp_value);
+    }
+  }
+
+  if (qosDscp->getValue () != DSCPValue::NO_VALUE) {
+    GST_INFO ("Setting QOS-DSCP value to %s", qosDscp->getString().c_str());
+    g_object_set (element, "qos-dscp", get_dscp_value (qosDscp), NULL);
+  }
+
 
   if (recvonly) {
     g_object_set (element, "offer-dir", GST_SDP_DIRECTION_RECVONLY, NULL);
@@ -1158,11 +1263,12 @@ MediaObjectImpl *
 WebRtcEndpointImplFactory::createObject (const boost::property_tree::ptree
     &conf, std::shared_ptr<MediaPipeline>
     mediaPipeline, bool recvonly, bool sendonly, bool useDataChannels,
-    std::shared_ptr<CertificateKeyType> certificateKeyType) const
+    std::shared_ptr<CertificateKeyType> certificateKeyType, 
+    std::shared_ptr<DSCPValue> qosDscp) const
 {
   return new WebRtcEndpointImpl (conf, mediaPipeline, recvonly,
                                  sendonly, useDataChannels,
-                                 certificateKeyType);
+                                 certificateKeyType, qosDscp);
 }
 
 WebRtcEndpointImpl::StaticConstructor WebRtcEndpointImpl::staticConstructor;

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -570,6 +570,14 @@ get_dscp_value (std::shared_ptr<DSCPValue> qosDscp)
     return 10;
   case DSCPValue::DATA_HIGH:
     return 18;
+  case DSCPValue::CHROME_HIGH:
+    return 56;
+  case DSCPValue::CHROME_MEDIUM:
+    return 56;
+  case DSCPValue::CHROME_LOW:
+    return 0;
+  case DSCPValue::CHROME_VERYLOW:
+    return 8;
   default:
     return -1;
   }

--- a/src/server/implementation/objects/WebRtcEndpointImpl.hpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.hpp
@@ -42,7 +42,8 @@ public:
   WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
                       std::shared_ptr<MediaPipeline> mediaPipeline,
                       bool recvonly, bool sendonly, bool useDataChannels,
-                      std::shared_ptr<CertificateKeyType> certificateKeyType);
+                      std::shared_ptr<CertificateKeyType> certificateKeyType, 
+                      std::shared_ptr<DSCPValue> qosDscp);
 
   ~WebRtcEndpointImpl () override;
 
@@ -144,6 +145,8 @@ private:
   std::map < std::string, std::shared_ptr<IceCandidatePair >> candidatePairs;
   std::map < std::string, std::shared_ptr<IceConnection>> iceConnectionState;
 
+  std::shared_ptr<DSCPValue> qosDscp;
+  
   std::mutex mut;
 
   class StaticConstructor

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -951,6 +951,10 @@ This could also happen in the middle of a session, though not likely.
         "DATA_LOW",                 //  DF (0)
         "DATA_MEDIUM",              //  AF11 (10)
         "DATA_HIGH",                //  AF21 (18)
+        "CHROME_HIGH",              // CS7 (56)
+        "CHROME_MEDIUM",            // CS7 (56)
+        "CHROME_LOW",               // CS0 (0)
+        "CHROME_VERYLOW",           // CS1 (8)
         "CS0",      //   0
         "CS1",      //   8        
         "CS2",      //  16
@@ -1005,6 +1009,8 @@ This could also happen in the middle of a session, though not likely.
       <p>
       Apart from the WebRTC recommended values, we also include all possible values are referenced in http://www.iana.org/assignments/dscp-registry/dscp-registry.xml of course some of 
       those values are synomims for the WebRTC recommended ones, they are included mainly for completeness
+      <p>
+      And as a last point, we include a shorthand for Chrome supported markings for low  (CS0), very low (CS1), medium (CS7) and high (CS7) priorities in priority property for RTCRtpSender parameters. See https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters
       <p>
       This only covers outgoing network packets form KMS, to complete the solution, DSCP must be also requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
       browser or client. On browser, the client application needs to use the following API https://www.w3.org/TR/webrtc-priority/"

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -511,10 +511,10 @@
               "doc": "DSCP value to be used in network traffic sent from this endpoint
               <p>
               If this parameter is present with a value different to NO_VALUE, all traffic sent from this WebRTCEndpoint will be marked with the correspondent
-              DSCP value according to the DiffServ architecture. This may provide beter handling of network traffic according to its characteristics associated to 
-              its DSCP value. This better handling include priority in forwarding traffic and probablity of packet drop in case of network congestion.
+              DSCP value according to the DiffServ architecture. This may provide better handling of network traffic according to its characteristics associated to 
+              its DSCP value. This better handling includes priority in forwarding traffic and probablity of packet drop in case of network congestion.
               <p>
-              It must be taken into account that on Internet not all intermediate routers ar guaranteed to enforce those DSCP values, even it is possible that 
+              It must be taken into account that on Internet not all intermediate routers are guaranteed to enforce those DSCP values, even it is possible that 
               certain routers just block traffic marked with specific DSCP values, as discussed here https://datatracker.ietf.org/doc/html/rfc8835#section-4.2.
               <p> 
               So, this feature must be managed with care and is mostly intended for private networks, where the network proprietor can configure and guarantee 
@@ -983,7 +983,7 @@ This could also happen in the middle of a session, though not likely.
       "doc": "Possible DSCP values 
       <p>
       WebRTC recommended values are taken from RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5 , These are the values from AUDIO_VERYLOW to DATA_HIGH. First element in the 
-      name indicates kind of traffic that it should apply to, the second indicates relative prioriy. For video, a third field would indicate if the traffic is intended for high throughput or not.
+      name indicates kind of traffic that it should apply to, the second indicates relative priority. For video, a third field would indicate if the traffic is intended for high throughput or not.
       As indicated on RFC 8837 section 5 diagram:
 
           +=======================+==========+=====+============+============+
@@ -1008,11 +1008,11 @@ This could also happen in the middle of a session, though not likely.
       As indicated also in RFC, non interactive video is not considered
       <p>
       Apart from the WebRTC recommended values, we also include all possible values are referenced in http://www.iana.org/assignments/dscp-registry/dscp-registry.xml of course some of 
-      those values are synomims for the WebRTC recommended ones, they are included mainly for completeness
+      those values are synonyms for the WebRTC recommended ones, they are included mainly for completeness
       <p>
       And as a last point, we include a shorthand for Chrome supported markings for low  (CS0), very low (CS1), medium (CS7) and high (CS7) priorities in priority property for RTCRtpSender parameters. See https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters
       <p>
-      This only covers outgoing network packets form KMS, to complete the solution, DSCP must be also requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
+      This only covers outgoing network packets from KMS, to complete the solution, DSCP must be also requested on client, unfortunately for traffic on the other direction, this must be requested to the 
       browser or client. On browser, the client application needs to use the following API https://www.w3.org/TR/webrtc-priority/"
     }
   ]

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -1004,7 +1004,10 @@ This could also happen in the middle of a session, though not likely.
       As indicated also in RFC, non interactive video is not considered
       <p>
       Apart from the WebRTC recommended values, we also include all possible values are referenced in http://www.iana.org/assignments/dscp-registry/dscp-registry.xml of course some of 
-      those values are synomims for the WebRTC recommended ones, they are included mainly for completeness"
+      those values are synomims for the WebRTC recommended ones, they are included mainly for completeness
+      <p>
+      This only covers outgoing network packets form KMS, to complete the solution, DSCP must be also requested on client, unfortunatelly for traffic on the other direction, this must be requested to the 
+      browser or client. On browser, the client application needs to use the following API https://www.w3.org/TR/webrtc-priority/"
     }
   ]
 }

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -935,7 +935,8 @@ This could also happen in the middle of a session, though not likely.
     {
       "typeFormat": "ENUM",
       "values": [
-        "NO_VALUE",                 //  -1
+        "NO_DSCP",                  //  -1 USed to signal that no DSCP feature is requested
+        "NO_VALUE",                 //  -1 Used to signal to use the default value configured in configuration file
         "AUDIO_VERYLOW",            //   LE (1)
         "AUDIO_LOW",                //   DF (0)        
         "AUDIO_MEDIUM",             //  EF (46)

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -505,6 +505,23 @@
               "type": "CertificateKeyType",
               "optional": true,
               "defaultValue": "RSA"
+            },
+            {
+              "name": "qosDscp",
+              "doc": "DSCP value to be used in network traffic sent from this endpoint
+              <p>
+              If this parameter is present with a value different to NO_VALUE, all traffic sent from this WebRTCEndpoint will be marked with the correspondent
+              DSCP value according to the DiffServ architecture. This may provide beter handling of network traffic according to its characteristics associated to 
+              its DSCP value. This better handling include priority in forwarding traffic and probablity of packet drop in case of network congestion.
+              <p>
+              It must be taken into account that on Internet not all intermediate routers ar guaranteed to enforce those DSCP values, even it is possible that 
+              certain routers just block traffic marked with specific DSCP values, as discussed here https://datatracker.ietf.org/doc/html/rfc8835#section-4.2.
+              <p> 
+              So, this feature must be managed with care and is mostly intended for private networks, where the network proprietor can configure and guarantee 
+              DSCP management in all routers.",
+              "type": "DSCPValue",
+              "optional": true,
+              "defaultValue": "NO_VALUE"
             }
           ]
         },
@@ -914,6 +931,79 @@ This could also happen in the middle of a session, though not likely.
         "RSA",
         "ECDSA"
       ]
+    },
+    {
+      "typeFormat": "ENUM",
+      "values": [
+        "NO_VALUE",                 //  -1
+        "AUDIO_VERYLOW",            //   LE (1)
+        "AUDIO_LOW",                //   DF (0)        
+        "AUDIO_MEDIUM",             //  EF (46)
+        "AUDIO_HIGH",               //  EF (46)
+        "VIDEO_VERYLOW",            //  LE (1)
+        "VIDEO_LOW",                //  DF (0)
+        "VIDEO_MEDIUM",             //  AF42 (36)
+        "VIDEO_MEDIUM_THROUGHPUT",  //  AF43 (38)
+        "VIDEO_HIGH",               //  AF42 (36)
+        "VIDEO_HIGH_THROUGHPUT",    //  AF41(34)
+        "DATA_VERYLOW",             //  LE (1)
+        "DATA_LOW",                 //  DF (0)
+        "DATA_MEDIUM",              //  AF11 (10)
+        "DATA_HIGH",                //  AF21 (18)
+        "CS0",      //   0
+        "CS1",      //   8        
+        "CS2",      //  16
+        "CS3",      //  24
+        "CS4",      //  32
+        "CS5",      //  40
+        "CS6",      //  48
+        "CS7",      //  56
+        "AF11",     //  10
+        "AF12",     //  12
+        "AF13",     //  14
+        "AF21",     //  18
+        "AF22",     //  20
+        "AF23",     //  22
+        "AF31",     //  26
+        "AF32",     //  28
+        "AF33",     //  30
+        "AF41",     //  34
+        "AF42",     //  36
+        "AF43",     //  38
+        "EF",       //  46
+        "VOICEADMIT", // 44
+        "LE"        //   1
+      ],
+      "name": "DSCPValue",
+      "doc": "Possible DSCP values 
+      <p>
+      WebRTC recommended values are taken from RFC 8837 https://datatracker.ietf.org/doc/html/rfc8837#section-5 , These are the values from AUDIO_VERYLOW to DATA_HIGH. First element in the 
+      name indicates kind of traffic that it should apply to, the second indicates relative prioriy. For video, a third field would indicate if the traffic is intended for high throughput or not.
+      As indicated on RFC 8837 section 5 diagram:
+
+          +=======================+==========+=====+============+============+
+          |       Flow Type       | Very Low | Low |   Medium   |    High    |
+          +=======================+==========+=====+============+============+
+          |         Audio         |  LE (1)  |  DF |  EF (46)   |  EF (46)   |
+          |                       |          | (0) |            |            |
+          +-----------------------+----------+-----+------------+------------+
+          +-----------------------+----------+-----+------------+------------+
+          |   Interactive Video   |  LE (1)  |  DF | AF42, AF43 | AF41, AF42 |
+          | with or without Audio |          | (0) |  (36, 38)  |  (34, 36)  |
+          +-----------------------+----------+-----+------------+------------+
+          +-----------------------+----------+-----+------------+------------+
+          | Non-Interactive Video |  LE (1)  |  DF | AF32, AF33 | AF31, AF32 |
+          | with or without Audio |          | (0) |  (28, 30)  |  (26, 28)  |
+          +-----------------------+----------+-----+------------+------------+
+          +-----------------------+----------+-----+------------+------------+
+          |          Data         |  LE (1)  |  DF |    AF11    |    AF21    |
+          |                       |          | (0) |            |            |
+          +-----------------------+----------+-----+------------+------------+
+
+      As indicated also in RFC, non interactive video is not considered
+      <p>
+      Apart from the WebRTC recommended values, we also include all possible values are referenced in http://www.iana.org/assignments/dscp-registry/dscp-registry.xml of course some of 
+      those values are synomims for the WebRTC recommended ones, they are included mainly for completeness"
     }
   ]
 }


### PR DESCRIPTION
## What is the current behavior you want to change?
Media Communication in Internet is subject to best effort service type and has to fight for shared resources in intermediate communication infrastructure. However there exist the DSCP/ToS mechanism that allows an easy tagging and classification of traffic that allows intermediate equipment to manage traffic differentiated and thus providing QoS networks: https://en.wikipedia.org/wiki/Differentiated_services

On RFC8837 there is a proposal to network packet markings using DSCP for WebRTC services: https://datatracker.ietf.org/doc/html/rfc8837#section-5

On modern network equipoment that honors the DSCP packet tagging, WebRTC media traffic can get better latency, priority and less packet drop probablitiy, thus enhancing overall communication quality.

## What is the new behavior provided by this change?
This change implements the ability to tag WebRTC outgoing traffic from Kurento with DSCP values according to https://datatracker.ietf.org/doc/html/rfc8837#section-5
It implements an optional parameter in WebRTCEndpoint constructor, that if present will mark all outgoing network packets with the specified DSCP value.
It also implements an additional configuration parameter in the WebRtcEndpoint.conf.ini configuration file that allows to specify the default DSCP value to apply to all WebRTCEndpoints when no value is specified in constructor.

Of course, this change only applies to outgoing traffic from Kurento media server, to build a complete communication, traffic from browser (or the other peer) should also be tagged accordingly. For browsers the WebRTC Priority Control API (https://www.w3.org/TR/webrtc-priority/) should be used if available.

It must be noted that DSCP markings are applied at the WebRTCEndpoint level so it applies to all streams managed by the same WebRTCEndpoint (audio, video, datachannel).

## How has this been tested.
It has been tested using one of the Kurento tutorials, and taking network dumps of the packets exchanged to verify that  DSCP/ToS markings have been applied corresponding to the parameter in constructor and/or configuration file.


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [Contribution Guidelines](https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md)
- [X] I have added an explanation of what the changes do and why they should be included
- [X] I have written new tests for the changes, as applicable, and have successfully run them locally
