### PR TITLE
data channel: do not overwrite ppid if it was successfully parsed from received data

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcdatachannelbin.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcdatachannelbin.c
@@ -1106,12 +1106,15 @@ kms_webrtc_data_channel_bin_push_buffer (KmsWebRtcDataChannelBin * self,
 
   gst_buffer_unmap (buffer, &info);
 
-  if (sctp_receive_meta != NULL &&
-      !kms_webrtc_data_channel_bin_get_ppid_from_meta (self,
-          sctp_receive_meta, is_empty, &ppid)) {
-    gst_buffer_unref (buffer);
+  /* if available, get PPID from received SCTP meta data */
+  /* otherwise set PPID based on is_binary and is_empty flags */
+  if (sctp_receive_meta != NULL) {
+    if (!kms_webrtc_data_channel_bin_get_ppid_from_meta (self,
+        sctp_receive_meta, is_empty, &ppid)) {
+      gst_buffer_unref(buffer);
 
-    return GST_FLOW_ERROR;
+      return GST_FLOW_ERROR;
+    }
   } else if (is_binary) {
     if (is_empty) {
       ppid = KMS_DATA_CHANNEL_PPID_BINARY_EMPTY;


### PR DESCRIPTION
## What is the current behavior you want to change?
Kurento overwrites the PPID of data channel packets marking every packet to be of type "String" even when they were sent marked as "Binary".

## What is the new behavior provided by this change?
This PR fixes the code that already tried to preserve the PPID of the SCTP source packet, but eventually overwrote it anyways.

## How has this been tested?
A simple data channel connection from Chrome browser to Chrome browser via Kurento previously failed to receive an ArrayBuffer object, if the ArrayBuffer contains any bytes with the most significant bit set (e.g. `new Uint8Array([255, 128]).buffer`). This is due the PPID set by Kurento to String type, so Chrome tries to parse the data as UTF8 string, which fails.
The change of the PPID can be seen in the Chrome debug logs when run with `--enable-logging --v=2`: packets sent with PPID 0x35 (binary) are turned into PPID 0x33 (string).
After this fix the PPID is preserved by Kurento when sending binary or string data.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md)
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
