### PR TITLE
Remove seek flags trickmode

### DIFF
--- a/src/gst-plugins/kmsplayerendpoint.c
+++ b/src/gst-plugins/kmsplayerendpoint.c
@@ -970,7 +970,7 @@ kms_player_endpoint_set_position (KmsPlayerEndpoint * self, gint64 position)
   }
 
   seek = gst_event_new_seek (1.0, GST_FORMAT_TIME,
-      GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_TRICKMODE | GST_SEEK_FLAG_ACCURATE,
+      GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE,
       /* start */ GST_SEEK_TYPE_SET, position,
       /* stop */ GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
 


### PR DESCRIPTION
On setting position, the seek event was created with flag GST_SEEK_FLAG_TRICKMODE. But it turns out that this flag forces libav codecs to put in AVDISCARD_NONREF mode, that is, to discard non reference frames, inlcuding B frames (https://github.com/GStreamer/gst-libav/blob/4f649c9556ce5b4501363885995554598303e01c/ext/libav/gstavviddec.c#L1537). This makes the playerendpoint, once setPosition is called, to enter a state of low framerate. This issue has been described before here https://github.com/Kurento/bugtracker/issues/438.

In a separate note, playerendpoint does not use agnosticbin to decode media, unless useEncodedMedia builder flag is set to true. So the uridecodebin just chooses the most adequate decoder based on rank. Regarding this issue, the playerendpoint (in fact uridecodebin) was choosing in many cases, particularly H264 files, the libav decoder (avdec_h264), which in turn caused the issue. Perhaps it would be nice to always force to use UseEncodedMedia flag to true, and leave the decoding task to agnosticbin.

Anyway, in some mp4 files that wouldn't cause any difference as openh264 (in kurento 6.x) is limited to baseline profile, so if mp4 file uses h264 high profile, libav decoder will be used.

<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
PlayerEndpoint is having low framerate after the setposition signal has been called in the playerendpoint plugin. It should maintain source original framerate and avoid skipping frames.


## What is the new behavior provided by this change?
<!--
Example: "Adding a function to do X",
then explain why it is necessary to have a way to do X.
-->
This change fixes the situation by changing the flags issues in the seek event that is used on setposition signal


## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, tests ran to see how
your change affects other areas of the code, etc.
-->
no boost test is provided, just tests have been done with a kurento tutorial verifying using gstreamer dumps the configuration of video decoder and also number of frames processed (videorate in and out statistics) 


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [Contribution Guidelines](https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md)
- [X] I have added an explanation of what the changes do and why they should be included
- [X] I have written new tests for the changes, as applicable, and have successfully run them locally

Fixes https://github.com/Kurento/bugtracker/issues/438